### PR TITLE
fix: enforce group membership on expense endpoints

### DIFF
--- a/Splitty-API/Splitty.API/Controllers/GroupController.cs
+++ b/Splitty-API/Splitty.API/Controllers/GroupController.cs
@@ -55,6 +55,8 @@ public class GroupController(
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
+        if (userId is null) return Unauthorized();
+
         var group = await groupService.GetGroupAsync(groupId, int.Parse(userId));
 
         return Ok(group);
@@ -96,6 +98,8 @@ public class GroupController(
 
         if (userId is null) return Unauthorized();
 
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
         var expenses = await expenseService.FindExpensesByGroupId(groupId, int.Parse(userId));
 
         return Ok(expenses);
@@ -116,6 +120,8 @@ public class GroupController(
 
         if (userId is null) return Unauthorized();
 
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
         var dto = new CreateExpenseDTO
         {
             Amount = request.Amount,
@@ -125,7 +131,7 @@ public class GroupController(
             ExpenseSplits = request.Splits
         };
 
-        var expense = await expenseService.CreateAsync(dto);
+        var expense = await expenseService.CreateAsync(dto, int.Parse(userId));
         
         await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
 
@@ -149,6 +155,8 @@ public class GroupController(
 
         if (userId is null) return Unauthorized();
 
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
         var dto = new UpdateExpenseDTO
         {
             Id = expenseId,
@@ -159,7 +167,7 @@ public class GroupController(
             ExpenseSplits = request.Splits
         };
 
-        var expense = await expenseService.UpdateAsync(dto);
+        var expense = await expenseService.UpdateAsync(dto, int.Parse(userId));
         
         await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
         
@@ -173,6 +181,8 @@ public class GroupController(
 
         if (userId is null) return Unauthorized();
 
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
         var balances = await balanceService.CalculateGroupBalances(groupId);
 
         return Ok(balances);
@@ -184,6 +194,8 @@ public class GroupController(
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
         if (userId is null) return Unauthorized();
+
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
 
         var balances = await balanceService.GetGroupUserBalance(groupId, int.Parse(userId));
 
@@ -197,6 +209,8 @@ public class GroupController(
 
         if (userId is null) return Unauthorized();
         
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
         await balanceService.SettleUp(groupId, int.Parse(userId), request.WithUserId, request.Amount);
 
         await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));

--- a/Splitty-API/Splitty.Service/BalanceService.cs
+++ b/Splitty-API/Splitty.Service/BalanceService.cs
@@ -7,7 +7,8 @@ namespace Splitty.Service;
 public class BalanceService(
     IBalanceRepository balanceRepository,
     IExpenseRepository expenseRepository,
-    IUserRepository userRepository
+    IUserRepository userRepository,
+    IGroupMembershipRepository groupMembershipRepository
 ) : IBalanceService
 {
     public async Task<List<Balance>> CalculateGroupBalances(int groupId)
@@ -65,11 +66,16 @@ public class BalanceService(
 
     public async Task<List<Balance>> GetGroupUserBalance(int groupId, int userId)
     {
+        await EnsureMemberAsync(groupId, userId);
+
         return await balanceRepository.GetUserGroupBalances(userId, groupId);
     }
 
     public async Task SettleUp(int groupId, int userId, int peerId, decimal amount)
     {
+        await EnsureMemberAsync(groupId, userId);
+        await EnsureMemberAsync(groupId, peerId);
+
         var payee = await userRepository.GetByIdAsync(peerId);
 
         if (payee is null)
@@ -100,5 +106,15 @@ public class BalanceService(
         };
 
         await expenseRepository.CreateAsync(settleExpense);
+    }
+
+    private async Task EnsureMemberAsync(int groupId, int userId)
+    {
+        var membership = await groupMembershipRepository.GetGroupMembershipByUserIdAndGroupId(userId, groupId);
+
+        if (membership is null)
+        {
+            throw new UnauthorizedAccessException("User is not a member of the group");
+        }
     }
 }

--- a/Splitty-API/Splitty.Service/ExpenseService.cs
+++ b/Splitty-API/Splitty.Service/ExpenseService.cs
@@ -64,15 +64,14 @@ public class ExpenseService(
 
         await EnsureMemberAsync(expense.GroupId, userId);
 
-        if (dto.PaidBy is not null)
-        {
-            await EnsureMemberAsync(expense.GroupId, dto.PaidBy.Value);
-        }
-
-        if (dto.ExpenseSplits is not null)
-        {
-            await EnsureMembersAsync(expense.GroupId, dto.ExpenseSplits.Select(s => s.UserId));
-        }
+        // Validate the resulting state, not just the supplied fields: an
+        // amount-only update must not leave a nonmember payer or split behind.
+        await EnsureMemberAsync(expense.GroupId, dto.PaidBy ?? expense.PaidBy);
+        await EnsureMembersAsync(
+            expense.GroupId,
+            dto.ExpenseSplits is not null
+                ? dto.ExpenseSplits.Select(s => s.UserId)
+                : expense.Splits.Select(s => s.UserId));
 
         expense.Amount = dto.Amount ?? expense.Amount;
         expense.Description = dto.Description ?? expense.Description;

--- a/Splitty-API/Splitty.Service/ExpenseService.cs
+++ b/Splitty-API/Splitty.Service/ExpenseService.cs
@@ -6,11 +6,16 @@ using Splitty.Service.Interfaces;
 namespace Splitty.Service;
 
 public class ExpenseService(
-    IExpenseRepository expenseRepository
+    IExpenseRepository expenseRepository,
+    IGroupMembershipRepository groupMembershipRepository
     ): IExpenseService
 {
-    public async Task<Expense> CreateAsync(CreateExpenseDTO dto)
+    public async Task<Expense> CreateAsync(CreateExpenseDTO dto, int userId)
     {
+        await EnsureMemberAsync(dto.GroupId, userId);
+        await EnsureMemberAsync(dto.GroupId, dto.PaidBy);
+        await EnsureMembersAsync(dto.GroupId, dto.ExpenseSplits.Select(s => s.UserId));
+
         var expense = new Expense
         {
             Amount = dto.Amount,
@@ -36,28 +41,41 @@ public class ExpenseService(
     
     public async Task<List<Expense>> FindExpensesByGroupId(int groupId, int userId)
     {
+        await EnsureMemberAsync(groupId, userId);
+
         return await expenseRepository.FindExpensesByGroupId(groupId);
     }
     
-    public async Task<Expense> UpdateAsync(UpdateExpenseDTO dto)
+    public async Task<Expense> UpdateAsync(UpdateExpenseDTO dto, int userId)
     {
         var expense = await expenseRepository.FindByIdAsync(dto.Id);
 
         if (expense is null)
         {
-            Console.WriteLine("Expense not found");
             throw new ArgumentException("Expense not found");
         }
-        
-        // if (expense.Group.Members.All(m => m.UserId != dto.PaidBy))
-        // {
-        //     Console.WriteLine("User is not a member of the group");
-        //     throw new UnauthorizedAccessException("User is not a member of the group");
-        // }
-        
+
+        // The expense must belong to the group the request was made against,
+        // otherwise a member of group A could edit an expense of group B.
+        if (dto.GroupId is not null && dto.GroupId != expense.GroupId)
+        {
+            throw new UnauthorizedAccessException("Expense does not belong to the group");
+        }
+
+        await EnsureMemberAsync(expense.GroupId, userId);
+
+        if (dto.PaidBy is not null)
+        {
+            await EnsureMemberAsync(expense.GroupId, dto.PaidBy.Value);
+        }
+
+        if (dto.ExpenseSplits is not null)
+        {
+            await EnsureMembersAsync(expense.GroupId, dto.ExpenseSplits.Select(s => s.UserId));
+        }
+
         expense.Amount = dto.Amount ?? expense.Amount;
         expense.Description = dto.Description ?? expense.Description;
-        expense.GroupId = dto.GroupId ?? expense.GroupId;
         expense.PaidBy = dto.PaidBy ?? expense.PaidBy;
         
         if (dto.ExpenseSplits is not null)
@@ -72,5 +90,23 @@ public class ExpenseService(
         
         await expenseRepository.UpdateAsync(expense);
         return expense;
+    }
+
+    private async Task EnsureMemberAsync(int groupId, int userId)
+    {
+        var membership = await groupMembershipRepository.GetGroupMembershipByUserIdAndGroupId(userId, groupId);
+
+        if (membership is null)
+        {
+            throw new UnauthorizedAccessException("User is not a member of the group");
+        }
+    }
+
+    private async Task EnsureMembersAsync(int groupId, IEnumerable<int> userIds)
+    {
+        foreach (var userId in userIds.Distinct())
+        {
+            await EnsureMemberAsync(groupId, userId);
+        }
     }
 }

--- a/Splitty-API/Splitty.Service/GroupService.cs
+++ b/Splitty-API/Splitty.Service/GroupService.cs
@@ -144,4 +144,9 @@ public class GroupService(
 
         return group;
     }
+
+    public async Task<bool> IsMemberAsync(int groupId, int userId)
+    {
+        return await groupMembershipRepository.GetGroupMembershipByUserIdAndGroupId(userId, groupId) is not null;
+    }
 }

--- a/Splitty-API/Splitty.Service/Interfaces/IExpenseService.cs
+++ b/Splitty-API/Splitty.Service/Interfaces/IExpenseService.cs
@@ -5,9 +5,9 @@ namespace Splitty.Service.Interfaces;
 
 public interface IExpenseService
 {
-    Task<Expense> CreateAsync(CreateExpenseDTO dto);
+    Task<Expense> CreateAsync(CreateExpenseDTO dto, int userId);
     Task<Expense?> FindByIdAsync(int id);
     // Task<Expense> UpdateAsync(Expense expense); 
     Task<List<Expense>> FindExpensesByGroupId(int groupId, int userId);
-    Task<Expense> UpdateAsync(UpdateExpenseDTO dto);
+    Task<Expense> UpdateAsync(UpdateExpenseDTO dto, int userId);
 }

--- a/Splitty-API/Splitty.Service/Interfaces/IGroupService.cs
+++ b/Splitty-API/Splitty.Service/Interfaces/IGroupService.cs
@@ -10,4 +10,5 @@ public interface IGroupService
     Task<List<GroupDTO>> GetGroupsByUserId(int userId);
     Task<Group> UpdateAsync(int groupId, int userId, string name, string? description);
     Task<Group> JoinGroupAsync(int groupId, int userId);
+    Task<bool> IsMemberAsync(int groupId, int userId);
 }


### PR DESCRIPTION
## Problem

Every group-scoped expense/balance route was authenticated but not authorized. Any logged-in user could act on any group:

- `GET /group/{id}/expenses` — `userId` was parsed then discarded; `ExpenseService.FindExpensesByGroupId` ignored it.
- `POST /group/{id}/expenses` — no membership check; caller could inject expenses into any group and set `PaidBy` to an arbitrary user.
- `PUT /group/{id}/expenses/{expenseId}` — membership check was commented out, and `expense.GroupId` was overwritten from the DTO without verifying it matched, allowing cross-group expense hijack.
- `POST /group/{id}/settle` — no membership check; debt-clearing expense could be written to any group.
- `GET|POST /group/{id}/expenses/summary` — no membership check.

## Fix

- `IGroupService.IsMemberAsync` (backed by the already-existing, previously unused `IGroupMembershipRepository.GetGroupMembershipByUserIdAndGroupId`) guards every group-scoped route in `GroupController`, returning 403.
- Defense in depth in the services: `ExpenseService` and `BalanceService` take `IGroupMembershipRepository` and verify membership for the acting user, `PaidBy`, `peerId`, and every split user.
- `ExpenseService.UpdateAsync` rejects a `GroupId` that differs from the expense's group and no longer reassigns `GroupId`.
- `GetGroupById` now returns 401 on a missing subject claim instead of throwing on `int.Parse(null)`.

`CalculateGroupBalances(groupId)` keeps its signature because `TransactionBackgroundService` calls it with no user context; the endpoint that exposes it is guarded at the controller.

## Verification

`dotnet build` — 9 projects, 0 errors (37 pre-existing warnings).