### PR TITLE
fix: create DI scope per transaction message

### DIFF
--- a/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
+++ b/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
@@ -1,31 +1,22 @@
 ﻿using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Splitty.Service;
 using Splitty.Service.Interfaces;
 
 namespace Splitty.Background;
 
-public class TransactionBackgroundService: BackgroundService
+public class TransactionBackgroundService(
+    Channel<TransactionRequest> channel,
+    IServiceScopeFactory serviceScopeFactory
+) : BackgroundService
 {
-    private readonly Channel<TransactionRequest> _channel;
-    private readonly IBalanceService _balanceService;
-    
-    public TransactionBackgroundService(Channel<TransactionRequest> channel,
-        IServiceScopeFactory serviceScopeFactory
-        )
-    {
-        _channel = channel;
-        var scope = serviceScopeFactory.CreateScope();
-        _balanceService = scope.ServiceProvider.GetRequiredService<IBalanceService>();
-    }
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (await _channel.Reader.WaitToReadAsync(stoppingToken))
+        await foreach (var request in channel.Reader.ReadAllAsync(stoppingToken))
         {
-            var request = await _channel.Reader.ReadAsync(stoppingToken);
-            await _balanceService.CalculateGroupBalances(request.groupId);
+            using var scope = serviceScopeFactory.CreateScope();
+            var balanceService = scope.ServiceProvider.GetRequiredService<IBalanceService>();
+            await balanceService.CalculateGroupBalances(request.groupId);
         }
     }
 }


### PR DESCRIPTION
## Problem

`TransactionBackgroundService` resolved `IBalanceService` from a scope created in its constructor and never disposed it:

```csharp
var scope = serviceScopeFactory.CreateScope();
_balanceService = scope.ServiceProvider.GetRequiredService<IBalanceService>();
```

`BackgroundService` is registered as a singleton, so this captured the scoped `ApplicationDbContext` for the lifetime of the process. Two consequences:

- **Unbounded memory growth** — the change tracker accumulated every entity from every balance recalculation and was never reset.
- **Concurrency hazard** — `DbContext` is not thread-safe. Balance recalculations for different groups shared one instance.

## Fix

Create and dispose a scope per channel message, so each `CalculateGroupBalances` call gets a fresh `DbContext`. Also switched the read loop to `ReadAllAsync` and moved to a primary constructor.

## Verification

`dotnet build Splitty.sln` — 0 errors. The 38 warnings are pre-existing `CS8618` on domain entities; none are in this file.

Not covered by automated tests — the solution has no test project.