### PR TITLE
fix: unique index on User.Email

### DIFF
--- a/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
+++ b/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
@@ -35,6 +35,7 @@ public class ApplicationDbContext : DbContext
             entity.HasKey(u => u.Id);
             entity.Property(u => u.Name).IsRequired().HasMaxLength(255);
             entity.Property(u => u.Email).IsRequired().HasMaxLength(255);
+            entity.HasIndex(u => u.Email).IsUnique();
             entity.Property(u => u.Password).IsRequired();
             entity.Property(u => u.AvatarUrl).HasMaxLength(255);
             entity.Property(u => u.CreatedAt).IsRequired();

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260819135918_Unique_User_Email.Designer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260819135918_Unique_User_Email.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Splitty.Infrastructure;
@@ -11,9 +12,11 @@ using Splitty.Infrastructure;
 namespace Splitty.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819135918_Unique_User_Email")]
+    partial class Unique_User_Email
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260819135918_Unique_User_Email.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260819135918_Unique_User_Email.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Splitty.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Unique_User_Email : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "AvatarUrl",
+                table: "User",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            // Duplicate emails were possible before the unique index existed;
+            // keep the earliest user per email so the index can be created.
+            migrationBuilder.Sql("""
+                CREATE TEMP TABLE user_email_extras AS
+                SELECT u."Id" AS extra_id, k.keeper_id
+                FROM "User" u
+                JOIN (
+                    SELECT "Email", MIN("Id") AS keeper_id
+                    FROM "User"
+                    GROUP BY "Email"
+                ) k ON k."Email" = u."Email"
+                WHERE u."Id" <> k.keeper_id;
+
+                UPDATE "Group" g
+                SET "CreatedBy" = e.keeper_id
+                FROM user_email_extras e
+                WHERE g."CreatedBy" = e.extra_id;
+
+                UPDATE "Invite" i
+                SET "CreatedBy" = e.keeper_id
+                FROM user_email_extras e
+                WHERE i."CreatedBy" = e.extra_id;
+
+                UPDATE "Expense" x
+                SET "PaidBy" = e.keeper_id
+                FROM user_email_extras e
+                WHERE x."PaidBy" = e.extra_id;
+
+                UPDATE "ExpenseSplit" s
+                SET "UserId" = e.keeper_id
+                FROM user_email_extras e
+                WHERE s."UserId" = e.extra_id;
+
+                UPDATE "Balance" b
+                SET "UserId" = e.keeper_id
+                FROM user_email_extras e
+                WHERE b."UserId" = e.extra_id;
+
+                UPDATE "Balance" b
+                SET "PeerId" = e.keeper_id
+                FROM user_email_extras e
+                WHERE b."PeerId" = e.extra_id;
+
+                DELETE FROM "GroupMembership" m
+                USING user_email_extras e
+                WHERE m."UserId" = e.extra_id
+                  AND EXISTS (
+                      SELECT 1
+                      FROM "GroupMembership" k
+                      WHERE k."UserId" = e.keeper_id
+                        AND k."GroupId" = m."GroupId"
+                  );
+
+                UPDATE "GroupMembership" m
+                SET "UserId" = e.keeper_id
+                FROM user_email_extras e
+                WHERE m."UserId" = e.extra_id;
+
+                DELETE FROM "User" u
+                USING user_email_extras e
+                WHERE u."Id" = e.extra_id;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_User_Email",
+                table: "User",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_User_Email",
+                table: "User");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AvatarUrl",
+                table: "User",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+        }
+    }
+}

--- a/Splitty-API/Splitty.Repository/UserRepository.cs
+++ b/Splitty-API/Splitty.Repository/UserRepository.cs
@@ -9,8 +9,19 @@ public class UserRepository(ApplicationDbContext context): IUserRepository
 {
     public async Task CreateAsync(User user)
     {
-        await context.User.AddAsync(user);
-        await context.SaveChangesAsync();
+        var entry = await context.User.AddAsync(user);
+
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (ex.IsUniqueViolation())
+        {
+            // Leaving the failed insert tracked would replay it on the next save.
+            entry.State = EntityState.Detached;
+
+            throw new InvalidOperationException("User with this email already exists.");
+        }
     }
 
     public async Task<User?> GetByEmailAsync(string email)


### PR DESCRIPTION
## Summary
- Add a unique index on `User.Email` so concurrent registrations cannot insert the same address (invite codes already had this, email did not).
- Map unique-violation on insert to the existing "email already exists" error instead of a 500.
- Migration remaps FKs onto the earliest row per email before creating the index, so existing duplicates do not block apply.

## Test plan
- [ ] Apply `Unique_User_Email` against a DB that already has users.
- [ ] Register with an email that exists: still 400 with "User with this email already exists."
- [ ] Two overlapping registers with the same new email: one succeeds, the other gets the same 400 (not 500).
- [ ] Login with that email reaches the surviving account.


Made with [Cursor](https://cursor.com)