### PR TITLE
refactor: queue balance recomputation and expose pending state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ riderModule.iml
 # XCode
 *.xcuserstate
 xcuserdata/
+.DS_Store

--- a/Splitty-API/Splitty.API.Tests/ApiClient.cs
+++ b/Splitty-API/Splitty.API.Tests/ApiClient.cs
@@ -79,6 +79,40 @@ public sealed class ApiClient
 
     public Task<HttpResponseMessage> UpdateExpenseAsync(int groupId, int expenseId, object body) =>
         _http.PutAsJsonAsync($"/group/{groupId}/expenses/{expenseId}", body);
+
+    public Task<HttpResponseMessage> RequestSummaryRefreshAsync(int groupId) =>
+        _http.PostAsync($"/group/{groupId}/expenses/summary", null);
+
+    public Task<HttpResponseMessage> GetSummaryAsync(int groupId) =>
+        _http.GetAsync($"/group/{groupId}/expenses/summary");
+
+    public Task<HttpResponseMessage> SettleUpAsync(int groupId, object body) =>
+        _http.PostAsJsonAsync($"/group/{groupId}/settle", body);
+
+    public async Task<BalanceSummary> ReadSummaryAsync(int groupId)
+    {
+        var response = await GetSummaryAsync(groupId);
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+        var balances = body.GetProperty("balances")
+            .EnumerateArray()
+            .Select(b => new BalanceEntry(
+                b.GetProperty("userId").GetInt32(),
+                b.GetProperty("peerId").GetInt32(),
+                b.GetProperty("amount").GetDecimal()))
+            .ToList();
+
+        return new BalanceSummary(balances, body.GetProperty("balancesPending").GetBoolean());
+    }
 }
 
 public readonly record struct RegisteredUser(int Id, string Name, string Email, string Token);
+
+public sealed record BalanceSummary(IReadOnlyList<BalanceEntry> Balances, bool BalancesPending)
+{
+    public decimal AmountOwedBy(int userId, int peerId) =>
+        Balances.Single(b => b.UserId == userId && b.PeerId == peerId).Amount;
+}
+
+public readonly record struct BalanceEntry(int UserId, int PeerId, decimal Amount);

--- a/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Splitty.Domain.Entities;
+using Splitty.Service;
+using Splitty.Service.Interfaces;
+
+namespace Splitty.API.Tests;
+
+[Collection(nameof(ApiCollection))]
+public sealed class BalanceRecomputationTests(ApiFactory factory)
+{
+    [Fact]
+    public async Task Editing_an_expense_amount_changes_the_balance_derived_from_it()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+
+        var afterCreate = await group.Owner.ReadSummaryAsync(group.Id);
+        Assert.Equal(10m, afterCreate.AmountOwedBy(group.OwnerId, group.GuestId));
+
+        // The second recomputation in the same process is the one a captive scope breaks:
+        // a context living for the process lifetime replays the amounts it first loaded.
+        (await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new
+        {
+            amount = 50m,
+            splits = new[]
+            {
+                new { userId = group.OwnerId, amount = 25m },
+                new { userId = group.GuestId, amount = 25m }
+            }
+        })).EnsureSuccessStatusCode();
+        await factory.WaitForProcessedAsync();
+
+        var afterEdit = await group.Owner.ReadSummaryAsync(group.Id);
+        Assert.Equal(25m, afterEdit.AmountOwedBy(group.OwnerId, group.GuestId));
+    }
+
+    [Fact]
+    public async Task Manual_refresh_returns_202_with_no_body()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        var response = await group.Owner.RequestSummaryRefreshAsync(group.Id);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+
+        await factory.WaitForProcessedAsync();
+    }
+
+    [Fact]
+    public async Task Manual_refresh_updates_balances_once_the_worker_drains()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        // Write the expense straight to the database so the only thing that can produce a
+        // balance for it is the recomputation the refresh request enqueues.
+        await group.InsertExpenseDirectlyAsync(amount: 30m, share: 15m);
+
+        Assert.Empty((await group.Owner.ReadSummaryAsync(group.Id)).Balances);
+
+        (await group.Owner.RequestSummaryRefreshAsync(group.Id)).EnsureSuccessStatusCode();
+        await factory.WaitForProcessedAsync();
+
+        var summary = await group.Owner.ReadSummaryAsync(group.Id);
+        Assert.Equal(15m, summary.AmountOwedBy(group.OwnerId, group.GuestId));
+    }
+
+    [Fact]
+    public async Task Summary_reports_balances_pending_until_the_worker_drains()
+    {
+        using var gate = new RecomputeGate();
+        await using var gated = factory.WithGate(gate);
+
+        var group = await GroupFixture.CreateAsync(gated);
+        await gated.DrainProcessedAsync();
+
+        await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        await gate.WaitForEntryAsync();
+        Assert.True((await group.Owner.ReadSummaryAsync(group.Id)).BalancesPending);
+
+        gate.Release();
+        await gated.WaitForProcessedAsync();
+
+        Assert.False((await group.Owner.ReadSummaryAsync(group.Id)).BalancesPending);
+    }
+
+    [Fact]
+    public async Task Settling_up_marks_balances_pending()
+    {
+        using var gate = new RecomputeGate();
+        await using var gated = factory.WithGate(gate);
+
+        var group = await GroupFixture.CreateAsync(gated);
+        await gated.DrainProcessedAsync();
+
+        (await group.Owner.SettleUpAsync(group.Id, new { withUserId = group.GuestId, amount = 5m }))
+            .EnsureSuccessStatusCode();
+
+        await gate.WaitForEntryAsync();
+        Assert.True((await group.Owner.ReadSummaryAsync(group.Id)).BalancesPending);
+
+        gate.Release();
+        await gated.WaitForProcessedAsync();
+    }
+
+    [Fact]
+    public async Task A_failed_recomputation_is_logged_with_its_group_id_and_the_worker_keeps_serving()
+    {
+        var logs = new CapturingLoggerProvider();
+        int poisonedGroupId = 0;
+
+        await using var host = factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddSingleton<ILoggerProvider>(logs);
+                services.AddScoped<IBalanceService>(provider => new PoisonedBalanceService(
+                    ActivatorUtilities.CreateInstance<BalanceService>(provider),
+                    () => poisonedGroupId));
+            }));
+
+        var poisoned = await GroupFixture.CreateAsync(host);
+        var healthy = await GroupFixture.CreateAsync(host);
+        poisonedGroupId = poisoned.Id;
+        await host.DrainProcessedAsync();
+
+        await poisoned.CreateExpenseAsync(amount: 20m, share: 10m);
+        await host.WaitForProcessedAsync();
+
+        Assert.Contains(logs.Errors, entry => entry.Contains(poisoned.Id.ToString()));
+
+        // The host is still up: another endpoint serves, and another group still recomputes.
+        Assert.Equal(HttpStatusCode.OK, (await healthy.Owner.GetGroupAsync(healthy.Id)).StatusCode);
+
+        await healthy.CreateExpenseAsync(amount: 40m, share: 20m);
+        await host.WaitForProcessedAsync();
+
+        Assert.Equal(20m, (await healthy.Owner.ReadSummaryAsync(healthy.Id))
+            .AmountOwedBy(healthy.OwnerId, healthy.GuestId));
+    }
+
+    [Fact]
+    public async Task Concurrent_mutations_and_refreshes_leave_one_balance_row_per_ordered_pair()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        const int rounds = 8;
+
+        for (var i = 0; i < rounds; i++)
+        {
+            await Task.WhenAll(
+                group.CreateExpenseAsync(amount: 10m, share: 5m),
+                group.Owner.RequestSummaryRefreshAsync(group.Id));
+        }
+
+        await factory.WaitForProcessedAsync(rounds * 2);
+
+        var duplicated = await factory.UseDbAsync(db => db.Balance
+            .Where(b => b.GroupId == group.Id)
+            .GroupBy(b => new { b.UserId, b.PeerId })
+            .Where(g => g.Count() > 1)
+            .CountAsync());
+
+        Assert.Equal(0, duplicated);
+    }
+
+    /// <summary>
+    /// Skipping a unique index on the balance triple is only safe while the worker is the sole
+    /// replayer. Nothing at the call site enforces that, so it is enforced here.
+    /// </summary>
+    [Fact]
+    public void The_balance_replay_has_exactly_one_caller()
+    {
+        var callers = SolutionSource.FilesCalling("CalculateGroupBalances")
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}Splitty.API.Tests{Path.DirectorySeparatorChar}"))
+            .Where(path => !path.EndsWith("IBalanceService.cs", StringComparison.Ordinal))
+            .Where(path => !path.EndsWith("BalanceService.cs", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(
+            ["TransactionBackgroundService.cs"],
+            callers.Select(Path.GetFileName).Order().ToList());
+    }
+
+    private sealed class PoisonedBalanceService(IBalanceService inner, Func<int> poisonedGroupId) : IBalanceService
+    {
+        public Task<List<Balance>> CalculateGroupBalances(int groupId) =>
+            groupId == poisonedGroupId()
+                ? throw new InvalidOperationException("recompute failed")
+                : inner.CalculateGroupBalances(groupId);
+
+        public Task<List<Balance>> GetGroupUserBalance(int groupId, int userId) =>
+            inner.GetGroupUserBalance(groupId, userId);
+
+        public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
+            inner.SettleUp(groupId, userId, peerId, amount);
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
@@ -118,7 +118,7 @@ public sealed class BalanceRecomputationTests(ApiFactory factory)
     public async Task A_failed_recomputation_is_logged_with_its_group_id_and_the_worker_keeps_serving()
     {
         var logs = new CapturingLoggerProvider();
-        int poisonedGroupId = 0;
+        var poisonedGroup = new PoisonedGroup();
 
         await using var host = factory.WithWebHostBuilder(builder =>
             builder.ConfigureTestServices(services =>
@@ -126,12 +126,12 @@ public sealed class BalanceRecomputationTests(ApiFactory factory)
                 services.AddSingleton<ILoggerProvider>(logs);
                 services.AddScoped<IBalanceService>(provider => new PoisonedBalanceService(
                     ActivatorUtilities.CreateInstance<BalanceService>(provider),
-                    () => poisonedGroupId));
+                    poisonedGroup));
             }));
 
         var poisoned = await GroupFixture.CreateAsync(host);
         var healthy = await GroupFixture.CreateAsync(host);
-        poisonedGroupId = poisoned.Id;
+        poisonedGroup.Id = poisoned.Id;
         await host.DrainProcessedAsync();
 
         await poisoned.CreateExpenseAsync(amount: 20m, share: 10m);
@@ -193,17 +193,27 @@ public sealed class BalanceRecomputationTests(ApiFactory factory)
             callers.Select(Path.GetFileName).Order().ToList());
     }
 
-    private sealed class PoisonedBalanceService(IBalanceService inner, Func<int> poisonedGroupId) : IBalanceService
+    /// <summary>
+    /// The group under test is chosen after the host is built, so the worker thread reads
+    /// what the test thread wrote.
+    /// </summary>
+    private sealed class PoisonedGroup
     {
-        public Task<List<Balance>> CalculateGroupBalances(int groupId) =>
-            groupId == poisonedGroupId()
+        private int _id;
+
+        public int Id
+        {
+            get => Volatile.Read(ref _id);
+            set => Volatile.Write(ref _id, value);
+        }
+    }
+
+    private sealed class PoisonedBalanceService(IBalanceService inner, PoisonedGroup poisoned)
+        : BalanceServiceDecorator(inner)
+    {
+        public override Task<List<Balance>> CalculateGroupBalances(int groupId) =>
+            groupId == poisoned.Id
                 ? throw new InvalidOperationException("recompute failed")
-                : inner.CalculateGroupBalances(groupId);
-
-        public Task<List<Balance>> GetGroupUserBalance(int groupId, int userId) =>
-            inner.GetGroupUserBalance(groupId, userId);
-
-        public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
-            inner.SettleUp(groupId, userId, peerId, amount);
+                : base.CalculateGroupBalances(groupId);
     }
 }

--- a/Splitty-API/Splitty.API.Tests/BalanceServiceDecorator.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceServiceDecorator.cs
@@ -1,0 +1,20 @@
+using Splitty.Domain.Entities;
+using Splitty.Service.Interfaces;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Passes every call through, so a test substitute only has to say how the one method
+/// it cares about differs.
+/// </summary>
+public abstract class BalanceServiceDecorator(IBalanceService inner) : IBalanceService
+{
+    public virtual Task<List<Balance>> CalculateGroupBalances(int groupId) =>
+        inner.CalculateGroupBalances(groupId);
+
+    public Task<List<Balance>> GetGroupUserBalance(int groupId, int userId) =>
+        inner.GetGroupUserBalance(groupId, userId);
+
+    public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
+        inner.SettleUp(groupId, userId, peerId, amount);
+}

--- a/Splitty-API/Splitty.API.Tests/CapturingLoggerProvider.cs
+++ b/Splitty-API/Splitty.API.Tests/CapturingLoggerProvider.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Splitty.API.Tests;
+
+public sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<string> _errors = new();
+
+    public IReadOnlyCollection<string> Errors => _errors;
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(_errors);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<string> errors) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                errors.Enqueue(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/GroupFixture.cs
+++ b/Splitty-API/Splitty.API.Tests/GroupFixture.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Splitty.Domain.Entities;
+using Splitty.Infrastructure;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// A group with two members and an authenticated client for each, the shape every
+/// balance assertion needs before it can say anything.
+/// </summary>
+public sealed class GroupFixture
+{
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly WebApplicationFactory<Program> _factory;
+
+    private GroupFixture(WebApplicationFactory<Program> factory, int id, ApiClient owner, int ownerId, int guestId)
+    {
+        _factory = factory;
+        Id = id;
+        Owner = owner;
+        OwnerId = ownerId;
+        GuestId = guestId;
+    }
+
+    public int Id { get; }
+    public ApiClient Owner { get; }
+    public int OwnerId { get; }
+    public int GuestId { get; }
+
+    public static async Task<GroupFixture> CreateAsync(WebApplicationFactory<Program> factory)
+    {
+        var ownerUser = await ApiClient.Create(factory).RegisterAsync(name: "Owner");
+        var owner = ApiClient.Create(factory, ownerUser.Token);
+        var groupId = await owner.CreateGroupAsync();
+        var code = await owner.CreateInviteAsync(groupId);
+
+        var guestUser = await ApiClient.Create(factory).RegisterAsync(name: "Guest");
+        var guest = ApiClient.Create(factory, guestUser.Token);
+        (await guest.AcceptInviteAsync(code)).EnsureSuccessStatusCode();
+
+        return new GroupFixture(factory, groupId, owner, ownerUser.Id, guestUser.Id);
+    }
+
+    public async Task<int> CreateExpenseAsync(decimal amount, decimal share)
+    {
+        var response = await Owner.CreateExpenseAsync(Id, new
+        {
+            paidBy = OwnerId,
+            amount,
+            description = "Dinner",
+            splits = new[]
+            {
+                new { userId = OwnerId, amount = share },
+                new { userId = GuestId, amount = share }
+            }
+        });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+        return body.GetProperty("id").GetInt32();
+    }
+
+    /// <summary>
+    /// Bypasses the endpoint so no recomputation is enqueued, leaving an expense that only
+    /// an explicitly requested replay can turn into a balance.
+    /// </summary>
+    public async Task InsertExpenseDirectlyAsync(decimal amount, decimal share)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.Expense.Add(new Expense
+        {
+            GroupId = Id,
+            Description = "Unreplayed",
+            Amount = amount,
+            PaidBy = OwnerId,
+            Type = ExpenseType.Expense,
+            Splits =
+            [
+                new ExpenseSplit { UserId = OwnerId, Amount = share },
+                new ExpenseSplit { UserId = GuestId, Amount = share }
+            ]
+        });
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/InviteAcceptanceTests.cs
+++ b/Splitty-API/Splitty.API.Tests/InviteAcceptanceTests.cs
@@ -88,6 +88,9 @@ public sealed class InviteAcceptanceTests
         public Task<MembershipRemovalStatus> RemoveMemberAsync(int groupId, int actorId, int targetUserId) =>
             inner.RemoveMemberAsync(groupId, actorId, targetUserId);
 
+        public Task<bool> AreBalancesPendingAsync(int groupId) =>
+            inner.AreBalancesPendingAsync(groupId);
+
         public Task<bool> IsMemberAsync(int groupId, int userId) =>
             inner.IsMemberAsync(groupId, userId);
     }

--- a/Splitty-API/Splitty.API.Tests/RecomputeGate.cs
+++ b/Splitty-API/Splitty.API.Tests/RecomputeGate.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Splitty.Domain.Entities;
+using Splitty.Service;
+using Splitty.Service.Interfaces;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Holds a recomputation open so a test can observe the window in which balances are
+/// pending, instead of guessing whether the worker has already drained.
+/// </summary>
+public sealed class RecomputeGate : IDisposable
+{
+    private static readonly TimeSpan EntryTimeout = TimeSpan.FromSeconds(15);
+
+    private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task WaitForEntryAsync() => _entered.Task.WaitAsync(EntryTimeout);
+
+    public void Release() => _released.TrySetResult();
+
+    // Releasing on dispose keeps a failed assertion from stranding the worker.
+    public void Dispose() => Release();
+
+    internal void SignalEntered() => _entered.TrySetResult();
+
+    internal Task WaitForReleaseAsync() => _released.Task;
+}
+
+public static class RecomputeGateExtensions
+{
+    public static WebApplicationFactory<Program> WithGate(
+        this WebApplicationFactory<Program> factory,
+        RecomputeGate gate) =>
+        factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services.AddScoped<IBalanceService>(provider => new GatedBalanceService(
+                    ActivatorUtilities.CreateInstance<BalanceService>(provider),
+                    gate))));
+
+    private sealed class GatedBalanceService(IBalanceService inner, RecomputeGate gate) : IBalanceService
+    {
+        public async Task<List<Balance>> CalculateGroupBalances(int groupId)
+        {
+            gate.SignalEntered();
+            await gate.WaitForReleaseAsync();
+            return await inner.CalculateGroupBalances(groupId);
+        }
+
+        public Task<List<Balance>> GetGroupUserBalance(int groupId, int userId) =>
+            inner.GetGroupUserBalance(groupId, userId);
+
+        public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
+            inner.SettleUp(groupId, userId, peerId, amount);
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/RecomputeGate.cs
+++ b/Splitty-API/Splitty.API.Tests/RecomputeGate.cs
@@ -41,19 +41,14 @@ public static class RecomputeGateExtensions
                     ActivatorUtilities.CreateInstance<BalanceService>(provider),
                     gate))));
 
-    private sealed class GatedBalanceService(IBalanceService inner, RecomputeGate gate) : IBalanceService
+    private sealed class GatedBalanceService(IBalanceService inner, RecomputeGate gate)
+        : BalanceServiceDecorator(inner)
     {
-        public async Task<List<Balance>> CalculateGroupBalances(int groupId)
+        public override async Task<List<Balance>> CalculateGroupBalances(int groupId)
         {
             gate.SignalEntered();
             await gate.WaitForReleaseAsync();
-            return await inner.CalculateGroupBalances(groupId);
+            return await base.CalculateGroupBalances(groupId);
         }
-
-        public Task<List<Balance>> GetGroupUserBalance(int groupId, int userId) =>
-            inner.GetGroupUserBalance(groupId, userId);
-
-        public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
-            inner.SettleUp(groupId, userId, peerId, amount);
     }
 }

--- a/Splitty-API/Splitty.API.Tests/SolutionSource.cs
+++ b/Splitty-API/Splitty.API.Tests/SolutionSource.cs
@@ -1,0 +1,27 @@
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Reads the solution's own source, for invariants that are about which code exists
+/// rather than about what a request returns.
+/// </summary>
+public static class SolutionSource
+{
+    public static IEnumerable<string> FilesCalling(string identifier) =>
+        Directory.EnumerateFiles(Root(), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            .Where(path => File.ReadAllText(path).Contains(identifier, StringComparison.Ordinal));
+
+    private static string Root()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Splitty.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+               ?? throw new InvalidOperationException("Could not locate Splitty.sln above the test assembly.");
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/WorkerHarness.cs
+++ b/Splitty-API/Splitty.API.Tests/WorkerHarness.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Splitty.Background;
+using Splitty.Infrastructure;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Turns the worker's per-message completion signal into assertions that await a drain
+/// instead of racing it.
+/// </summary>
+public static class WorkerHarness
+{
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Consumes completions left over from earlier tests sharing this host, so a later
+    /// wait counts only the messages the calling test enqueued.
+    /// </summary>
+    public static async Task DrainProcessedAsync(this WebApplicationFactory<Program> factory)
+    {
+        var signal = factory.Services.GetRequiredService<TransactionProcessedSignal>();
+        while (await signal.WaitAsync(TimeSpan.Zero))
+        {
+        }
+    }
+
+    public static async Task WaitForProcessedAsync(this WebApplicationFactory<Program> factory, int count = 1)
+    {
+        var signal = factory.Services.GetRequiredService<TransactionProcessedSignal>();
+
+        for (var i = 0; i < count; i++)
+        {
+            Assert.True(
+                await signal.WaitAsync(DrainTimeout),
+                $"Timed out waiting for message {i + 1} of {count} to be processed.");
+        }
+    }
+
+    public static async Task<T> UseDbAsync<T>(
+        this WebApplicationFactory<Program> factory,
+        Func<ApplicationDbContext, Task<T>> query)
+    {
+        using var scope = factory.Services.CreateScope();
+        return await query(scope.ServiceProvider.GetRequiredService<ApplicationDbContext>());
+    }
+}

--- a/Splitty-API/Splitty.API/Controllers/GroupController.cs
+++ b/Splitty-API/Splitty.API/Controllers/GroupController.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Splitty.Background;
@@ -19,7 +18,7 @@ public class GroupController(
     IExpenseService expenseService,
     IBalanceService balanceService,
     IInviteService inviteService,
-    Channel<TransactionRequest> balanceChannel
+    IBalanceRecomputeQueue balanceRecomputeQueue
 ) : ControllerBase
 {
     [HttpPost]
@@ -204,7 +203,7 @@ public class GroupController(
 
         var expense = await expenseService.CreateAsync(dto, int.Parse(userId));
         
-        await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
 
         return Ok(expense);
     }
@@ -240,13 +239,17 @@ public class GroupController(
 
         var expense = await expenseService.UpdateAsync(dto, int.Parse(userId));
         
-        await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
         
         return Ok(expense);
     }
     
+    /// <summary>
+    /// Requests a recomputation rather than performing one. Replaying inline would race the
+    /// worker replaying the same group, and both would insert the pairwise row neither found.
+    /// </summary>
     [HttpPost("{groupId}/expenses/summary")]
-    public async Task<ActionResult<List<Balance>>> CalculateExpenseSummary(int groupId)
+    public async Task<ActionResult> RequestExpenseSummaryRefresh(int groupId)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
@@ -254,13 +257,13 @@ public class GroupController(
 
         if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
 
-        var balances = await balanceService.CalculateGroupBalances(groupId);
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
 
-        return Ok(balances);
+        return Accepted();
     }
     
     [HttpGet("{groupId}/expenses/summary")]
-    public async Task<ActionResult<List<Balance>>> GetExpenseSummary(int groupId)
+    public async Task<ActionResult<GroupBalanceSummaryResponse>> GetExpenseSummary(int groupId)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
@@ -270,7 +273,11 @@ public class GroupController(
 
         var balances = await balanceService.GetGroupUserBalance(groupId, int.Parse(userId));
 
-        return Ok(balances);
+        return Ok(new GroupBalanceSummaryResponse
+        {
+            Balances = balances,
+            BalancesPending = await groupService.AreBalancesPendingAsync(groupId)
+        });
     }
     
     [HttpPost("{groupId}/settle")]
@@ -284,7 +291,7 @@ public class GroupController(
 
         await balanceService.SettleUp(groupId, int.Parse(userId), request.WithUserId, request.Amount);
 
-        await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
 
         return Ok();
     }

--- a/Splitty-API/Splitty.API/Controllers/GroupController.cs
+++ b/Splitty-API/Splitty.API/Controllers/GroupController.cs
@@ -271,12 +271,14 @@ public class GroupController(
 
         if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
 
-        var balances = await balanceService.GetGroupUserBalance(groupId, int.Parse(userId));
+        // Read before the balances: a drain landing between the two reads then reports
+        // fresh balances as pending, rather than stale balances as settled.
+        var balancesPending = await groupService.AreBalancesPendingAsync(groupId);
 
         return Ok(new GroupBalanceSummaryResponse
         {
-            Balances = balances,
-            BalancesPending = await groupService.AreBalancesPendingAsync(groupId)
+            Balances = await balanceService.GetGroupUserBalance(groupId, int.Parse(userId)),
+            BalancesPending = balancesPending
         });
     }
     

--- a/Splitty-API/Splitty.API/Program.cs
+++ b/Splitty-API/Splitty.API/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddScoped<IInviteService, InviteService>();
 builder.Services.AddScoped<IPasswordHasher, PasswordHasher>();
 
 // Background
+builder.Services.AddScoped<IBalanceRecomputeQueue, BalanceRecomputeQueue>();
 builder.Services.AddSingleton<TransactionProcessedSignal>();
 builder.Services.AddHostedService<TransactionBackgroundService>();
 

--- a/Splitty-API/Splitty.Background/BalanceRecomputeQueue.cs
+++ b/Splitty-API/Splitty.Background/BalanceRecomputeQueue.cs
@@ -1,0 +1,30 @@
+using System.Threading.Channels;
+using Splitty.Repository.Interfaces;
+
+namespace Splitty.Background;
+
+/// <summary>
+/// The only supported way to request a balance recomputation.
+/// </summary>
+public interface IBalanceRecomputeQueue
+{
+    Task EnqueueAsync(int groupId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Marks the group's balances pending and hands the recomputation to the worker.
+///
+/// The pending flag is written before the message is queued: queueing first would let the
+/// worker clear a flag this call has not set yet, leaving the group pending forever.
+/// </summary>
+public sealed class BalanceRecomputeQueue(
+    Channel<TransactionRequest> channel,
+    IGroupRepository groupRepository
+) : IBalanceRecomputeQueue
+{
+    public async Task EnqueueAsync(int groupId, CancellationToken cancellationToken = default)
+    {
+        await groupRepository.SetBalancesPendingAsync(groupId, true);
+        await channel.Writer.WriteAsync(new TransactionRequest(groupId), cancellationToken);
+    }
+}

--- a/Splitty-API/Splitty.Background/BalanceRecomputeQueue.cs
+++ b/Splitty-API/Splitty.Background/BalanceRecomputeQueue.cs
@@ -24,7 +24,7 @@ public sealed class BalanceRecomputeQueue(
 {
     public async Task EnqueueAsync(int groupId, CancellationToken cancellationToken = default)
     {
-        await groupRepository.SetBalancesPendingAsync(groupId, true);
+        await groupRepository.MarkBalancesPendingAsync(groupId);
         await channel.Writer.WriteAsync(new TransactionRequest(groupId), cancellationToken);
     }
 }

--- a/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
+++ b/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Splitty.Repository.Interfaces;
 using Splitty.Service.Interfaces;
 
 namespace Splitty.Background;
@@ -22,6 +23,9 @@ public class TransactionBackgroundService(
                 using var scope = serviceScopeFactory.CreateScope();
                 var balanceService = scope.ServiceProvider.GetRequiredService<IBalanceService>();
                 await balanceService.CalculateGroupBalances(request.groupId);
+
+                var groupRepository = scope.ServiceProvider.GetRequiredService<IGroupRepository>();
+                await groupRepository.SetBalancesPendingAsync(request.groupId, false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
+++ b/Splitty-API/Splitty.Background/TransactionBackgroundService.cs
@@ -25,7 +25,7 @@ public class TransactionBackgroundService(
                 await balanceService.CalculateGroupBalances(request.groupId);
 
                 var groupRepository = scope.ServiceProvider.GetRequiredService<IGroupRepository>();
-                await groupRepository.SetBalancesPendingAsync(request.groupId, false);
+                await groupRepository.MarkBalancesRecomputedAsync(request.groupId);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/Splitty-API/Splitty.Background/TransactionProcessedSignal.cs
+++ b/Splitty-API/Splitty.Background/TransactionProcessedSignal.cs
@@ -8,4 +8,7 @@ public sealed class TransactionProcessedSignal
 
     public Task WaitAsync(CancellationToken cancellationToken = default) =>
         _processed.WaitAsync(cancellationToken);
+
+    public Task<bool> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>
+        _processed.WaitAsync(timeout, cancellationToken);
 }

--- a/Splitty-API/Splitty.DTO/Response/GroupBalanceSummaryResponse.cs
+++ b/Splitty-API/Splitty.DTO/Response/GroupBalanceSummaryResponse.cs
@@ -1,0 +1,14 @@
+using Splitty.Domain.Entities;
+
+namespace Splitty.DTO.Response;
+
+public class GroupBalanceSummaryResponse
+{
+    public List<Balance> Balances { get; init; } = [];
+
+    /// <summary>
+    /// True while a recomputation is queued or in flight, so the client can offer a refresh
+    /// instead of silently presenting figures that predate the last write.
+    /// </summary>
+    public bool BalancesPending { get; init; }
+}

--- a/Splitty-API/Splitty.Domain/Entities/Group.cs
+++ b/Splitty-API/Splitty.Domain/Entities/Group.cs
@@ -16,6 +16,12 @@ public class Group
     public int CreatedBy { get; set; }
     
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Set whenever a balance recomputation is enqueued, cleared by the worker once it replays.
+    /// A display hint only: nothing branches on it for correctness.
+    /// </summary>
+    public bool BalancesPending { get; set; }
     
     public virtual User CreatedByUser { get; set; }
     

--- a/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
+++ b/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
@@ -49,6 +49,7 @@ public class ApplicationDbContext : DbContext
             entity.Property(g => g.Description).HasMaxLength(500);
             entity.Property(g => g.CreatedAt).IsRequired();
             entity.Property(g => g.CreatedBy).IsRequired();
+            entity.Property(g => g.BalancesPending).IsRequired().HasDefaultValue(false);
 
             entity.HasOne(g => g.CreatedByUser)
                 .WithMany()

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260820003609_Add_Group_Balances_Pending.Designer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260820003609_Add_Group_Balances_Pending.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Splitty.Infrastructure;
@@ -11,9 +12,11 @@ using Splitty.Infrastructure;
 namespace Splitty.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820003609_Add_Group_Balances_Pending")]
+    partial class Add_Group_Balances_Pending
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260820003609_Add_Group_Balances_Pending.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260820003609_Add_Group_Balances_Pending.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Splitty.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Group_Balances_Pending : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "BalancesPending",
+                table: "Group",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BalancesPending",
+                table: "Group");
+        }
+    }
+}

--- a/Splitty-API/Splitty.Repository/GroupRepository.cs
+++ b/Splitty-API/Splitty.Repository/GroupRepository.cs
@@ -50,4 +50,19 @@ public class GroupRepository(ApplicationDbContext context): IGroupRepository
         context.Group.Remove(group);
         await context.SaveChangesAsync();
     }
+
+    public async Task SetBalancesPendingAsync(int groupId, bool pending)
+    {
+        await context.Group
+            .Where(g => g.Id == groupId)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(g => g.BalancesPending, pending));
+    }
+
+    public async Task<bool> GetBalancesPendingAsync(int groupId)
+    {
+        return await context.Group
+            .Where(g => g.Id == groupId)
+            .Select(g => g.BalancesPending)
+            .FirstOrDefaultAsync();
+    }
 }

--- a/Splitty-API/Splitty.Repository/GroupRepository.cs
+++ b/Splitty-API/Splitty.Repository/GroupRepository.cs
@@ -51,7 +51,15 @@ public class GroupRepository(ApplicationDbContext context): IGroupRepository
         await context.SaveChangesAsync();
     }
 
-    public async Task SetBalancesPendingAsync(int groupId, bool pending)
+    public Task MarkBalancesPendingAsync(int groupId) => SetBalancesPendingAsync(groupId, true);
+
+    public Task MarkBalancesRecomputedAsync(int groupId) => SetBalancesPendingAsync(groupId, false);
+
+    // Updated in the database rather than through a tracked entity, so the flag can be written
+    // without loading the group's members and balances. The tracker is left untouched: a Group
+    // already loaded in this scope keeps its old flag value, so callers must not save one back
+    // after flipping the flag.
+    private async Task SetBalancesPendingAsync(int groupId, bool pending)
     {
         await context.Group
             .Where(g => g.Id == groupId)

--- a/Splitty-API/Splitty.Repository/Interfaces/IGroupRepository.cs
+++ b/Splitty-API/Splitty.Repository/Interfaces/IGroupRepository.cs
@@ -9,6 +9,7 @@ public interface IGroupRepository
     Task<List<Group>> GetGroupsByUserId(int userId);
     Task UpdateAsync(Group group);
     Task DeleteAsync(Group group);
-    Task SetBalancesPendingAsync(int groupId, bool pending);
+    Task MarkBalancesPendingAsync(int groupId);
+    Task MarkBalancesRecomputedAsync(int groupId);
     Task<bool> GetBalancesPendingAsync(int groupId);
 }

--- a/Splitty-API/Splitty.Repository/Interfaces/IGroupRepository.cs
+++ b/Splitty-API/Splitty.Repository/Interfaces/IGroupRepository.cs
@@ -9,4 +9,6 @@ public interface IGroupRepository
     Task<List<Group>> GetGroupsByUserId(int userId);
     Task UpdateAsync(Group group);
     Task DeleteAsync(Group group);
+    Task SetBalancesPendingAsync(int groupId, bool pending);
+    Task<bool> GetBalancesPendingAsync(int groupId);
 }

--- a/Splitty-API/Splitty.Service/GroupService.cs
+++ b/Splitty-API/Splitty.Service/GroupService.cs
@@ -151,4 +151,9 @@ public class GroupService(
     {
         return await groupMembershipRepository.GetGroupMembershipByUserIdAndGroupId(userId, groupId) is not null;
     }
+
+    public async Task<bool> AreBalancesPendingAsync(int groupId)
+    {
+        return await groupRepository.GetBalancesPendingAsync(groupId);
+    }
 }

--- a/Splitty-API/Splitty.Service/Interfaces/IGroupService.cs
+++ b/Splitty-API/Splitty.Service/Interfaces/IGroupService.cs
@@ -21,4 +21,5 @@ public interface IGroupService
     Task<MembershipRemovalStatus> LeaveAsync(int groupId, int userId);
     Task<MembershipRemovalStatus> RemoveMemberAsync(int groupId, int actorId, int targetUserId);
     Task<bool> IsMemberAsync(int groupId, int userId);
+    Task<bool> AreBalancesPendingAsync(int groupId);
 }


### PR DESCRIPTION
## Summary
- Queue balance refreshes through a background worker to avoid concurrent recomputation races.
- Track and expose pending balance state in group summaries.
- Add database migration and comprehensive API tests for recomputation, failures, refreshes, and concurrency.

## Testing
- Added integration coverage for expense edits, manual refreshes, pending states, worker failures, and concurrent requests.
- Added invariant test ensuring the balance replay has a single production caller.
- Not run.