### PR TITLE
Bound settlement amounts to what is actually owed

### DIFF
--- a/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
@@ -98,13 +98,19 @@ public sealed class BalanceRecomputationTests(ApiFactory factory)
     [Fact]
     public async Task Settling_up_marks_balances_pending()
     {
+        // The settle cap reads balances the worker wrote, so the expense has to be replayed
+        // before the gate goes up: a gated group has no balances and nothing to settle.
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+
         using var gate = new RecomputeGate();
         await using var gated = factory.WithGate(gate);
-
-        var group = await GroupFixture.CreateAsync(gated);
         await gated.DrainProcessedAsync();
 
-        (await group.Owner.SettleUpAsync(group.Id, new { withUserId = group.GuestId, amount = 5m }))
+        var guest = ApiClient.Create(gated, group.GuestToken);
+        (await guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 5m }))
             .EnsureSuccessStatusCode();
 
         await gate.WaitForEntryAsync();

--- a/Splitty-API/Splitty.API.Tests/GroupFixture.cs
+++ b/Splitty-API/Splitty.API.Tests/GroupFixture.cs
@@ -17,19 +17,35 @@ public sealed class GroupFixture
 
     private readonly WebApplicationFactory<Program> _factory;
 
-    private GroupFixture(WebApplicationFactory<Program> factory, int id, ApiClient owner, int ownerId, int guestId)
+    private GroupFixture(
+        WebApplicationFactory<Program> factory,
+        int id,
+        ApiClient owner,
+        int ownerId,
+        ApiClient guest,
+        int guestId,
+        string guestToken)
     {
         _factory = factory;
         Id = id;
         Owner = owner;
         OwnerId = ownerId;
+        Guest = guest;
         GuestId = guestId;
+        GuestToken = guestToken;
     }
 
     public int Id { get; }
     public ApiClient Owner { get; }
     public int OwnerId { get; }
+    public ApiClient Guest { get; }
     public int GuestId { get; }
+
+    /// <summary>
+    /// Lets a test reach the same guest through a differently configured host, which is how
+    /// an assertion about the gated worker still acts as a real member.
+    /// </summary>
+    public string GuestToken { get; }
 
     public static async Task<GroupFixture> CreateAsync(WebApplicationFactory<Program> factory)
     {
@@ -42,7 +58,7 @@ public sealed class GroupFixture
         var guest = ApiClient.Create(factory, guestUser.Token);
         (await guest.AcceptInviteAsync(code)).EnsureSuccessStatusCode();
 
-        return new GroupFixture(factory, groupId, owner, ownerUser.Id, guestUser.Id);
+        return new GroupFixture(factory, groupId, owner, ownerUser.Id, guest, guestUser.Id, guestUser.Token);
     }
 
     public async Task<int> CreateExpenseAsync(decimal amount, decimal share)

--- a/Splitty-API/Splitty.API.Tests/SettlementBoundsTests.cs
+++ b/Splitty-API/Splitty.API.Tests/SettlementBoundsTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using Splitty.Domain.Entities;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Settling stays unilateral — one member, one request, no confirmation — but bounded by
+/// what the caller actually owes the peer.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class SettlementBoundsTests(ApiFactory factory)
+{
+    /// <summary>
+    /// The owner pays for both, so the guest owes the owner half and is the only member
+    /// with anything to settle.
+    /// </summary>
+    private async Task<GroupFixture> GroupWhereGuestOwesAsync(decimal owed)
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        await group.CreateExpenseAsync(amount: owed * 2, share: owed);
+        await factory.WaitForProcessedAsync();
+
+        return group;
+    }
+
+    [Fact]
+    public async Task Settling_more_than_is_owed_is_rejected()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var response = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 10.01m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Settling_less_than_is_owed_succeeds()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var response = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 4m });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+        Assert.Equal(-6m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    [Fact]
+    public async Task Settling_exactly_what_is_owed_leaves_the_pairwise_balance_at_zero()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var response = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 10m });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+
+        var summary = await group.Guest.ReadSummaryAsync(group.Id);
+        Assert.Equal(0m, summary.AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    [Fact]
+    public async Task A_settlement_takes_one_request_from_one_member_with_no_confirmation()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        (await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 10m }))
+            .EnsureSuccessStatusCode();
+        await factory.WaitForProcessedAsync();
+
+        // The owner is never asked to confirm, and the balance is already settled for them.
+        Assert.Equal(0m, (await group.Owner.ReadSummaryAsync(group.Id)).AmountOwedBy(group.OwnerId, group.GuestId));
+    }
+
+    [Fact]
+    public async Task Settling_zero_or_a_negative_amount_is_rejected()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var zero = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 0m });
+        var negative = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = -5m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(zero, HttpStatusCode.BadRequest);
+        await ErrorResponseAssertions.AssertErrorAsync(negative, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Settling_with_oneself_is_rejected()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var response = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.GuestId, amount = 5m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// The cap reads the balance table, so a group the worker has not replayed yet caps at
+    /// zero. Accepted: a retryable 400 rather than an unbounded settlement.
+    /// </summary>
+    [Fact]
+    public async Task Settling_against_a_group_with_no_computed_balances_is_rejected()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        await group.InsertExpenseDirectlyAsync(amount: 20m, share: 10m);
+
+        var response = await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 10m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task An_over_cap_rejection_reads_differently_from_a_malformed_amount()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        var overCap = await ErrorResponseAssertions.ReadErrorAsync(
+            await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 50m }));
+        var malformed = await ErrorResponseAssertions.ReadErrorAsync(
+            await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = -1m }));
+
+        Assert.NotEqual(overCap.Message, malformed.Message);
+        Assert.Contains("exceeds", overCap.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A_settlement_produces_two_splits_of_equal_magnitude_and_opposite_sign()
+    {
+        var group = await GroupWhereGuestOwesAsync(10m);
+
+        (await group.Guest.SettleUpAsync(group.Id, new { withUserId = group.OwnerId, amount = 7m }))
+            .EnsureSuccessStatusCode();
+        await factory.WaitForProcessedAsync();
+
+        var splits = await factory.UseDbAsync(db => db.Expense
+            .Where(e => e.GroupId == group.Id && e.Type == ExpenseType.Payment)
+            .SelectMany(e => e.Splits)
+            .Select(s => s.Amount)
+            .ToListAsync());
+
+        Assert.Equal(2, splits.Count);
+        Assert.Equal(0m, splits.Sum());
+        Assert.Equal(7m, splits.Max());
+    }
+}

--- a/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
+++ b/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
@@ -149,6 +149,10 @@ public class ApplicationDbContext : DbContext
             entity.HasKey(b => b.Id);
             entity.Property(b => b.Amount).IsRequired().HasColumnType("decimal(18,2)");
 
+            // The settle cap reads one row by this triple. Not unique: the replay is the
+            // sole writer and uniqueness there is enforced by that, not by the schema.
+            entity.HasIndex(b => new { b.GroupId, b.UserId, b.PeerId });
+
             entity.HasOne(b => b.User)
                 .WithMany()
                 .HasForeignKey(b => b.UserId)

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260820011351_Index_Balance_Group_User_Peer.Designer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260820011351_Index_Balance_Group_User_Peer.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Splitty.Infrastructure;
@@ -11,9 +12,11 @@ using Splitty.Infrastructure;
 namespace Splitty.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820011351_Index_Balance_Group_User_Peer")]
+    partial class Index_Balance_Group_User_Peer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260820011351_Index_Balance_Group_User_Peer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260820011351_Index_Balance_Group_User_Peer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Splitty.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Index_Balance_Group_User_Peer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Balance_GroupId",
+                table: "Balance");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Balance_GroupId_UserId_PeerId",
+                table: "Balance",
+                columns: new[] { "GroupId", "UserId", "PeerId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Balance_GroupId_UserId_PeerId",
+                table: "Balance");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Balance_GroupId",
+                table: "Balance",
+                column: "GroupId");
+        }
+    }
+}

--- a/Splitty-API/Splitty.Repository/BalanceRepository.cs
+++ b/Splitty-API/Splitty.Repository/BalanceRepository.cs
@@ -25,6 +25,16 @@ public class BalanceRepository(ApplicationDbContext context) : IBalanceRepositor
             .ToListAsync();
     }
     
+    /// <summary>
+    /// The single row the settle cap is read from. No includes: the cap needs the amount,
+    /// not the users behind it.
+    /// </summary>
+    public async Task<Balance?> GetPairwiseBalanceAsync(int userId, int peerId, int groupId)
+    {
+        return await context.Balance
+            .FirstOrDefaultAsync(b => b.UserId == userId && b.PeerId == peerId && b.GroupId == groupId);
+    }
+
     public async Task<List<Balance>> UpdateBalancesAsync(List<Balance> balances)
     {
         context.Balance.UpdateRange(balances);

--- a/Splitty-API/Splitty.Repository/Interfaces/IBalanceRepository.cs
+++ b/Splitty-API/Splitty.Repository/Interfaces/IBalanceRepository.cs
@@ -6,5 +6,6 @@ public interface IBalanceRepository
 {
     Task<List<Balance>> GetGroupBalancesAsync(int groupId);
     Task<List<Balance>> GetUserGroupBalances(int userId, int groupId);
+    Task<Balance?> GetPairwiseBalanceAsync(int userId, int peerId, int groupId);
     Task<List<Balance>> UpdateBalancesAsync(List<Balance> balances);
 }

--- a/Splitty-API/Splitty.Service/BalanceService.cs
+++ b/Splitty-API/Splitty.Service/BalanceService.cs
@@ -73,6 +73,16 @@ public class BalanceService(
 
     public async Task SettleUp(int groupId, int userId, int peerId, decimal amount)
     {
+        if (userId == peerId)
+        {
+            throw new ArgumentException("A settlement must be recorded against another member.");
+        }
+
+        if (amount <= 0)
+        {
+            throw new ArgumentException("Settlement amount must be greater than zero.");
+        }
+
         await EnsureMemberAsync(groupId, userId);
         await EnsureMemberAsync(groupId, peerId);
 
@@ -81,6 +91,14 @@ public class BalanceService(
         if (payee is null)
         {
             throw new KeyNotFoundException("User not found");
+        }
+
+        var owed = await AmountOwedAsync(groupId, userId, peerId);
+
+        if (amount > owed)
+        {
+            throw new ArgumentException(
+                $"Settlement amount exceeds the {owed} owed to {payee.Name}.");
         }
 
         var settleExpense = new Expense
@@ -105,7 +123,25 @@ public class BalanceService(
             }
         };
 
+        ExpenseSplitInvariants.Ensure(
+            settleExpense.Type,
+            settleExpense.Amount,
+            settleExpense.Splits.Select(s => s.Amount));
+
         await expenseRepository.CreateAsync(settleExpense);
+    }
+
+    /// <summary>
+    /// What the caller may still settle with this peer, read from the stored pairwise row
+    /// rather than recomputed. The replay credits the payer, so a negative amount on the
+    /// caller's row is what the caller owes; anything else, including a group whose balances
+    /// the worker has not written yet, leaves nothing to settle.
+    /// </summary>
+    private async Task<decimal> AmountOwedAsync(int groupId, int userId, int peerId)
+    {
+        var balance = await balanceRepository.GetPairwiseBalanceAsync(userId, peerId, groupId);
+
+        return balance is { Amount: < 0 } ? -balance.Amount : 0;
     }
 
     private async Task EnsureMemberAsync(int groupId, int userId)

--- a/Splitty-API/Splitty.Service/ExpenseService.cs
+++ b/Splitty-API/Splitty.Service/ExpenseService.cs
@@ -12,7 +12,7 @@ public class ExpenseService(
 {
     public async Task<Expense> CreateAsync(CreateExpenseDTO dto, int userId)
     {
-        EnsureExpenseSplitInvariants(ExpenseType.Expense, dto.Amount, dto.ExpenseSplits.Select(s => s.Amount));
+        ExpenseSplitInvariants.Ensure(ExpenseType.Expense, dto.Amount, dto.ExpenseSplits.Select(s => s.Amount));
 
         var splits = dto.ExpenseSplits;
 
@@ -82,7 +82,7 @@ public class ExpenseService(
             ? dto.ExpenseSplits.Select(s => s.Amount)
             : expense.Splits.Select(s => s.Amount);
 
-        EnsureExpenseSplitInvariants(expense.Type, resultingAmount, resultingSplits);
+        ExpenseSplitInvariants.Ensure(expense.Type, resultingAmount, resultingSplits);
 
         expense.Amount = resultingAmount;
         expense.Description = dto.Description ?? expense.Description;
@@ -117,33 +117,6 @@ public class ExpenseService(
         foreach (var userId in userIds.Distinct())
         {
             await EnsureMemberAsync(groupId, userId);
-        }
-    }
-
-    private static void EnsureExpenseSplitInvariants(ExpenseType type, decimal amount, IEnumerable<decimal>? splitAmounts)
-    {
-        if (type != ExpenseType.Expense) return;
-
-        var splits = splitAmounts?.ToList();
-
-        if (splits is null || splits.Count == 0)
-        {
-            throw new ArgumentException("An expense must have at least one split.");
-        }
-
-        if (amount <= 0)
-        {
-            throw new ArgumentException("Expense amount must be greater than zero.");
-        }
-
-        if (splits.Any(split => split <= 0))
-        {
-            throw new ArgumentException("Expense splits must be greater than zero.");
-        }
-
-        if (splits.Sum() != amount)
-        {
-            throw new ArgumentException("Expense splits must sum to the total.");
         }
     }
 }

--- a/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
+++ b/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
@@ -1,0 +1,69 @@
+using Splitty.Domain.Entities;
+
+namespace Splitty.Service;
+
+/// <summary>
+/// The split shape each expense type is allowed to have. Scoped by type because the two
+/// types are built from opposite directions: an <see cref="ExpenseType.Expense"/> carries
+/// client-supplied splits and is validated as input, while an <see cref="ExpenseType.Payment"/>
+/// is constructed internally by the settle path and is asserted, never accepted from a client.
+/// </summary>
+internal static class ExpenseSplitInvariants
+{
+    public static void Ensure(ExpenseType type, decimal amount, IEnumerable<decimal>? splitAmounts)
+    {
+        var splits = splitAmounts?.ToList();
+
+        switch (type)
+        {
+            case ExpenseType.Expense:
+                EnsureExpense(amount, splits);
+                break;
+            case ExpenseType.Payment:
+                EnsurePayment(splits);
+                break;
+        }
+    }
+
+    private static void EnsureExpense(decimal amount, List<decimal>? splits)
+    {
+        if (splits is null || splits.Count == 0)
+        {
+            throw new ArgumentException("An expense must have at least one split.");
+        }
+
+        if (amount <= 0)
+        {
+            throw new ArgumentException("Expense amount must be greater than zero.");
+        }
+
+        if (splits.Any(split => split <= 0))
+        {
+            throw new ArgumentException("Expense splits must be greater than zero.");
+        }
+
+        if (splits.Sum() != amount)
+        {
+            throw new ArgumentException("Expense splits must sum to the total.");
+        }
+    }
+
+    /// <summary>
+    /// A payment moves one amount between exactly two people, so its splits are equal in
+    /// magnitude and opposite in sign. Violating this means the settle path built the
+    /// expense wrong, which is why it throws rather than reporting a validation failure.
+    /// </summary>
+    private static void EnsurePayment(List<decimal>? splits)
+    {
+        if (splits is null || splits.Count != 2)
+        {
+            throw new InvalidOperationException("A payment must have exactly two splits.");
+        }
+
+        if (splits[0] != -splits[1] || splits[0] == 0)
+        {
+            throw new InvalidOperationException(
+                "A payment's splits must be equal in magnitude and opposite in sign.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #9.

Settling was unbounded — any member could record any amount against any other member, with no cap and no check against what was actually owed. Since no endpoint deletes an expense, a fabricated `Payment` was permanent short of direct database access.

Settlement stays **fully unilateral**: one member, one request, no counterparty confirmation, no pending state, identical UX. It becomes bounded.

## What changed

- `BalanceService.SettleUp` rejects a non-positive amount, a peer equal to the caller, and an amount above what the caller owes that peer.
- `IBalanceRepository.GetPairwiseBalanceAsync` reads the single balance row the cap comes from. The replay credits the payer, so a negative amount on the caller's row is what the caller owes; anything else, including a missing row, caps at zero.
- The type-scoped split validation from #7 gained its `Payment` branch — exactly two splits, equal magnitude, opposite sign — and moved to a shared `ExpenseSplitInvariants` so both the expense path and the settle path use it. Payments are built internally and never accepted from a client, so that branch asserts construction rather than validating input.
- Non-unique index on `Balance (GroupId, UserId, PeerId)`, so the cap is one indexed row read. Deliberately not unique: the worker is the sole replayer and uniqueness is enforced there, per the existing test that pins that fact.

## Trade-offs

The cap reads the eventually-consistent balance table rather than computing a live aggregate. In the window between a group's first expense and the worker's first run, no balance row exists, the cap is zero, and every settlement is rejected. Accepted rather than special-cased: the staleness window is short and an over-tight cap is a retryable `400`, not a wrong number. Expect it when settling on a freshly seeded group.

The `Math.Abs` calls in the replay stay. With every expense split positive and every payment pair equal and opposite they are provably inert, but removing them changes derived-state behaviour beyond this ticket.

Two-sided settlement, where the counterparty confirms a pending record, is the correct end state for a money application and stays deferred.

## Client impact

An endpoint that always succeeded can now reject. The iOS client's "Settle up" button is still a `// TODO` stub and never calls `/group/{id}/settle`, so nothing there needs to handle the `400` yet.

## Tests

New `SettlementBoundsTests` covers over-cap, exact, under-cap, zero, negative, self, and no-computed-balances rejection; that a success is still one request with no confirmation; that the two rejection messages read differently; that a full settlement drains to a zero pairwise balance; and the two-split shape.

`Settling_up_marks_balances_pending` was restructured — it settled `5` against a gated group with no balances, which the cap now correctly rejects, so the expense is replayed before the gate goes up.

Full suite: 32 passed, 0 failed.