### PR TITLE
Reconcile the context document with the hardening work

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,17 @@ These are the rules the domain actually depends on:
 3. **Every group sub-resource checks membership.** Controller actions under
    `/group/{groupId}/...` call `groupService.IsMemberAsync(...)` and return `Forbid()`.
    Adding an endpoint without that check is the failure mode to watch for.
+4. **The balance replay has exactly one caller: the background worker.** Nothing in the
+   code enforces this — no visibility modifier, no analyzer, no constraint. It is what makes
+   duplicate pairwise rows impossible without a unique index on `(UserId, PeerId, GroupId)`,
+   so a second call site reintroduces the duplicates silently. A test pins the caller list;
+   this entry is why it exists. Request a recomputation, never perform one.
+5. **Settlements are capped at what the caller currently owes the peer.** Recording a
+   settlement stays unilateral — one member, one request, no counterparty confirmation — but
+   it cannot exceed the debt. The cap reads the eventually-consistent balance table rather
+   than a live aggregate, which is deliberate: an over-tight cap is a retryable `400`, not a
+   wrong number. The consequence is that a group whose balances the worker has not written
+   yet caps at zero and rejects every settlement.
 
 ## Balance recomputation
 
@@ -74,17 +85,29 @@ Balances are **derived state, recomputed wholesale** — never incrementally pat
 `BalanceService.CalculateGroupBalances` zeroes every balance for the group, replays all
 expenses and splits, and writes the result back. It's idempotent by construction.
 
-It runs asynchronously. Controllers that mutate money write to a channel instead of
-recomputing inline:
+It runs asynchronously. Controllers that mutate money enqueue instead of recomputing
+inline:
 
 ```csharp
-await balanceChannel.Writer.WriteAsync(new TransactionRequest(groupId));
+await balanceRecomputeQueue.EnqueueAsync(groupId);
 ```
 
-`Channel<TransactionRequest>` is an unbounded singleton with `SingleReader = true`;
-`TransactionBackgroundService` drains it. So **balances are eventually consistent** —
-right after creating an expense, a read may still return pre-expense numbers. The client
-must not assume a write is immediately reflected.
+`IBalanceRecomputeQueue` is the only supported way to ask for a recomputation — it marks
+the group pending and then writes to the channel, in that order, since queueing first lets
+the worker clear a flag the caller has not set yet. `Channel<TransactionRequest>` is an
+unbounded singleton with `SingleReader = true`; `TransactionBackgroundService` drains it,
+resolving a fresh scope per message.
+
+So **balances are eventually consistent** — right after creating an expense, a read may
+still return pre-expense numbers. The client must not assume a write is immediately
+reflected.
+
+`Group.BalancesPending`, surfaced as `balancesPending` on the summary response, says a
+recomputation is outstanding. It is a **display hint only**: it exists so a client can show
+a spinner instead of presenting stale numbers as final. Nothing branches on it for
+correctness, and nothing should — it is written and cleared by the queue and the worker, so
+treating it as a lock or a read barrier would be trusting a flag that is itself eventually
+consistent.
 
 ## Auth
 
@@ -148,10 +171,6 @@ Live problems, not style preferences:
 
 - **Secrets are committed.** `appsettings.json` contains the JWT signing key
   (`SplittySuperReallySecureSecretKey`) and the database password in plaintext.
-- **Captive dependency.** `TransactionBackgroundService` resolves `IBalanceService` from a
-  scope created once in its constructor and never disposed, so a scoped `DbContext` lives
-  for the process lifetime and accumulates tracked entities.
-- **`GetGroupById` returns `Ok(null)`** for non-members instead of 403/404.
 - **`APIClient.swift` calls `DELETE /group/{id}`**, which no controller implements — 405s.
 - **`GenerateJwtToken` uses `DateTime.Now`** for `expires`; it's interpreted as UTC, so
   token lifetime is shifted by the host's UTC offset.


### PR DESCRIPTION
Closes #10.

Targets `docs/context`, not `main` — `CONTEXT.md` lives only on that branch, having been deliberately kept out of the invite change. That branch existed only locally and had to be pushed for this PR to have a base.

## Removed from Known Issues

Both are fixed, and a stale entry costs more than a missing one — a reader can't tell a live problem from a closed one.

- The captive dependency: the worker resolving its balance service from a scope created once in its constructor and never disposed. Fixed in #8.
- `GetGroupById` returning `Ok(null)` for non-members. Fixed in #7.

The remaining three — committed secrets, `DateTime.Now` in token expiry, the iOS client calling an unimplemented group delete — are untouched. None are addressed by this work.

## Added as invariants

- **The balance replay has exactly one caller: the background worker.** This is what makes duplicate pairwise rows impossible without a unique index on the triple. Nothing in the code enforces or hints at it, so a second call site reintroduces the duplicates silently. The entry states that consequence and notes the test pinning the caller list.
- **Settlements are capped at what the caller currently owes the peer.** Unilateral, no confirmation, but bounded. Records that the cap reads the eventually-consistent balance table by design, and the consequence: an unreplayed group caps at zero and rejects.

## Eventual consistency

Describes `Group.BalancesPending` / `balancesPending` as a **display hint only** — it exists so a client can show a spinner rather than present stale numbers as final. Nothing branches on it for correctness, and the section says why nothing should: it is itself eventually consistent.

## One edit beyond the ticket

The recomputation section's code sample still showed a raw `balanceChannel.Writer.WriteAsync(...)`, which no longer exists — `IBalanceRecomputeQueue.EnqueueAsync` replaced it, and the ordering between the pending flag and the channel write is load-bearing. The snippet sits in the same section the balances-pending line lands in, and leaving a sample that names a vanished API would undercut the point of the ticket.