### PR TITLE
iOS: group create/edit sheet + join-by-code entry

### DIFF
--- a/Splitty/Splitty/Components/GroupCard.swift
+++ b/Splitty/Splitty/Components/GroupCard.swift
@@ -15,7 +15,7 @@ struct GroupCard: View {
     }
     
     var body: some View {
-        NavigationLink(destination: GroupView(groupId: group.id)) {
+        NavigationLink(value: group.id) {
             VStack {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading) {

--- a/Splitty/Splitty/Models/Groups.swift
+++ b/Splitty/Splitty/Models/Groups.swift
@@ -11,7 +11,7 @@ import Foundation
 struct Group: Codable, Identifiable {
     let id: Int
     let name: String
-    let description: String
+    let description: String?
     let netBalance: Double
     let createdAt: String
     let members: [GroupMember]

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -113,12 +113,13 @@ class APIClient {
         return try await request(endpoint: "/group/\(id)")
     }
     
-    func createGroup(name: String, description: String) async throws -> Group {
-        let body = ["name": name, "description": description]
+    func createGroup(name: String, description: String?) async throws -> GroupMutationResponse {
+        var body: [String: Any] = ["name": name]
+        if let description = description { body["description"] = description }
         return try await request(endpoint: "/group", method: .POST, body: body)
     }
     
-    func updateGroup(id: Int, name: String?, description: String?) async throws -> Group {
+    func updateGroup(id: Int, name: String?, description: String?) async throws -> GroupMutationResponse {
         var body: [String: Any] = [:]
         if let name = name { body["name"] = name }
         if let description = description { body["description"] = description }
@@ -127,6 +128,11 @@ class APIClient {
     
     func deleteGroup(id: Int) async throws {
         let _: EmptyResponse = try await request(endpoint: "/group/\(id)", method: .DELETE)
+    }
+    
+    // MARK: - Invites
+    func redeemInvite(code: String) async throws -> GroupDetail {
+        return try await request(endpoint: "/invite/\(code)/accept", method: .POST)
     }
     
     // MARK: - Expenses
@@ -229,10 +235,18 @@ struct LoginResponse: Codable {
     let user: User
 }
 
+// POST /group and PUT /group/{id} return the Group entity, which carries neither
+// netBalance nor MemberDTO rows. Only these fields are safe to decode.
+struct GroupMutationResponse: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let description: String?
+}
+
 struct GroupDetail: Codable, Identifiable {
     let id: Int
     let name: String
-    let description: String
+    let description: String?
     let netBalance: Double
     let createdAt: String
     let members: [GroupMember]

--- a/Splitty/Splitty/Services/GroupService.swift
+++ b/Splitty/Splitty/Services/GroupService.swift
@@ -12,7 +12,6 @@ class GroupService {
     
     private init() {}
     
-    // MARK: - Modern async/await methods
     func getGroups() async throws -> [Group] {
         return try await APIClient.shared.getGroups()
     }
@@ -21,11 +20,11 @@ class GroupService {
         return try await APIClient.shared.getGroup(id: id)
     }
     
-    func createGroup(name: String, description: String) async throws -> Group {
+    func createGroup(name: String, description: String?) async throws -> GroupMutationResponse {
         return try await APIClient.shared.createGroup(name: name, description: description)
     }
     
-    func updateGroup(id: Int, name: String?, description: String?) async throws -> Group {
+    func updateGroup(id: Int, name: String?, description: String?) async throws -> GroupMutationResponse {
         return try await APIClient.shared.updateGroup(id: id, name: name, description: description)
     }
     
@@ -33,26 +32,10 @@ class GroupService {
         return try await APIClient.shared.deleteGroup(id: id)
     }
     
-    // MARK: - Legacy callback methods for existing code
-    static func fetchGroups(completion: @escaping (Result<[Group], Error>) -> Void) {
-        Task {
-            do {
-                let groups = try await shared.getGroups()
-                completion(.success(groups))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-    
-    static func fetchGroupDetails(groupId: Int, completion: @escaping (Result<GroupDetail, Error>) -> Void) {
-        Task {
-            do {
-                let group = try await shared.getGroup(id: groupId)
-                completion(.success(group))
-            } catch {
-                completion(.failure(error))
-            }
-        }
+    /// Redeems an invite code. The response identifies the group — the caller never
+    /// supplies a group id. Redeeming a code for a group you already belong to
+    /// succeeds and returns that group.
+    func redeemInvite(code: String) async throws -> GroupDetail {
+        return try await APIClient.shared.redeemInvite(code: code)
     }
 }

--- a/Splitty/Splitty/ViewModels/GroupFormViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupFormViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  GroupFormViewModel.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// Backs the sheet used for both creating and editing a group. `existingGroup`
+/// decides which of the two it is; everything else is identical.
+@MainActor
+class GroupFormViewModel: ObservableObject {
+    @Published var name: String
+    @Published var description: String
+    @Published var errorMessage: String?
+    @Published var isSaving = false
+    
+    private let existingGroupId: Int?
+    
+    init(existingGroupId: Int? = nil, name: String = "", description: String = "") {
+        self.existingGroupId = existingGroupId
+        self.name = name
+        self.description = description
+    }
+    
+    var isEditing: Bool { existingGroupId != nil }
+    
+    var title: String { isEditing ? "Edit group" : "New group" }
+    
+    var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSaving
+    }
+    
+    /// Returns the saved group id on success, nil on failure.
+    func save() async -> Int? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return nil }
+        
+        let trimmedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+        
+        do {
+            if let groupId = existingGroupId {
+                let group = try await GroupService.shared.updateGroup(
+                    id: groupId,
+                    name: trimmedName,
+                    description: trimmedDescription
+                )
+                return group.id
+            } else {
+                let group = try await GroupService.shared.createGroup(
+                    name: trimmedName,
+                    description: trimmedDescription.isEmpty ? nil : trimmedDescription
+                )
+                return group.id
+            }
+        } catch {
+            errorMessage = Self.message(for: error)
+            return nil
+        }
+    }
+    
+    private static func message(for error: Error) -> String {
+        guard case APIError.httpError(let status) = error else {
+            return error.localizedDescription
+        }
+        switch status {
+        case 400: return "Check the name and try again."
+        case 403: return "You are not a member of this group."
+        case 404: return "This group no longer exists."
+        default: return "Something went wrong (\(status)). Try again."
+        }
+    }
+}

--- a/Splitty/Splitty/ViewModels/GroupViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupViewModel.swift
@@ -18,58 +18,26 @@ class GroupViewModel: ObservableObject {
     // This should be set from the current user's ID from AuthService
     private let currentUserId = 1 // TODO: Get from AuthService
     
-    func loadGroupData(groupId: Int) {
+    func loadGroupData(groupId: Int) async {
         isLoading = true
         errorMessage = ""
+        defer { isLoading = false }
         
-        print("🔄 Loading group data for groupId: \(groupId)")
+        async let groupResult = GroupService.shared.getGroup(id: groupId)
+        async let expensesResult = ExpenseService.shared.getExpenses(groupId: groupId)
         
-        // Load group details and expenses concurrently
-        let dispatchGroup = DispatchGroup()
-        
-        // Load group details
-        dispatchGroup.enter()
-        GroupService.fetchGroupDetails(groupId: groupId) { [weak self] result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let group):
-                    print("✅ Group details loaded: \(group.name)")
-                    self?.group = group
-                case .failure(let error):
-                    print("❌ Failed to load group: \(error)")
-                    self?.errorMessage = "Failed to load group: \(error.localizedDescription)"
-                }
-                dispatchGroup.leave()
-            }
+        do {
+            group = try await groupResult
+        } catch {
+            errorMessage = "Failed to load group: \(error.localizedDescription)"
         }
         
-        // Load expenses
-        dispatchGroup.enter()
-        ExpenseService.fetchGroupExpenses(groupId: groupId) { [weak self] result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let expenses):
-                    print("✅ Expenses loaded: \(expenses.count) expenses")
-                    for expense in expenses {
-                        print("📝 Expense: \(expense.id) - \(expense.description) - \(expense.amount)")
-                    }
-                    self?.expenses = expenses
-                    self?.groupedExpenses = Expense.groupExpensesByDate(expenses)
-                    print("📅 Grouped expenses: \(self?.groupedExpenses.count ?? 0) groups")
-                    for group in self?.groupedExpenses ?? [] {
-                        print("📅 Group: \(group.dateString) - \(group.expenses.count) expenses")
-                    }
-                case .failure(let error):
-                    print("❌ Failed to load expenses: \(error)")
-                    self?.errorMessage = "Failed to load expenses: \(error.localizedDescription)"
-                }
-                dispatchGroup.leave()
-            }
-        }
-        
-        dispatchGroup.notify(queue: .main) { [weak self] in
-            self?.isLoading = false
-            print("🏁 Finished loading group data")
+        do {
+            let loadedExpenses = try await expensesResult
+            expenses = loadedExpenses
+            groupedExpenses = Expense.groupExpensesByDate(loadedExpenses)
+        } catch {
+            errorMessage = "Failed to load expenses: \(error.localizedDescription)"
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/GroupsViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupsViewModel.swift
@@ -13,44 +13,13 @@ class GroupsViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var isLoading = false
     
-    func loadGroups() {
+    func loadGroups() async {
         isLoading = true
-        GroupService.fetchGroups { [weak self] result in
-            DispatchQueue.main.async {
-                self?.isLoading = false
-                switch result {
-                case .success(let fetchedGroups):
-                    print("✅ Loaded \(fetchedGroups.count) groups from /groups endpoint")
-                    for (index, group) in fetchedGroups.enumerated() {
-                        print("📋 Group \(index + 1): id=\(group.id), name='\(group.name)', netBalance=\(group.netBalance), members=\(group.members.count)")
-                    }
-                    self?.groups = fetchedGroups
-                case .failure(let error):
-                    print("❌ Failed to load groups: \(error.localizedDescription)")
-                    self?.errorMessage = error.localizedDescription
-                }
-            }
-        }
-    }
-    
-    func loadGroupsAsync() async {
-        isLoading = true
+        defer { isLoading = false }
         do {
-            let fetchedGroups = try await GroupService.shared.getGroups()
-            await MainActor.run {
-                print("✅ Loaded \(fetchedGroups.count) groups from /groups endpoint (async)")
-                for (index, group) in fetchedGroups.enumerated() {
-                    print("📋 Group \(index + 1): id=\(group.id), name='\(group.name)', netBalance=\(group.netBalance), members=\(group.members.count)")
-                }
-                self.groups = fetchedGroups
-                self.isLoading = false
-            }
+            groups = try await GroupService.shared.getGroups()
         } catch {
-            await MainActor.run {
-                print("❌ Failed to load groups (async): \(error.localizedDescription)")
-                self.errorMessage = error.localizedDescription
-                self.isLoading = false
-            }
+            errorMessage = error.localizedDescription
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/JoinGroupViewModel.swift
+++ b/Splitty/Splitty/ViewModels/JoinGroupViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  JoinGroupViewModel.swift
+//  Splitty
+//
+
+import SwiftUI
+
+@MainActor
+class JoinGroupViewModel: ObservableObject {
+    static let codeLength = 6
+    private static let allowedCharacters = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+    
+    @Published var errorMessage: String?
+    @Published var isRedeeming = false
+    @Published var code: String = "" {
+        didSet {
+            let normalized = Self.normalize(code)
+            if normalized != code { code = normalized }
+        }
+    }
+    
+    var canRedeem: Bool { code.count == Self.codeLength && !isRedeeming }
+    
+    /// Uppercases as typed and drops anything outside A-Z0-9, capped at the code length.
+    static func normalize(_ input: String) -> String {
+        let filtered = input.uppercased().unicodeScalars.filter { allowedCharacters.contains($0) }
+        return String(String.UnicodeScalarView(filtered.prefix(codeLength)))
+    }
+    
+    /// Returns the joined group on success, nil on failure. Redeeming a code for a
+    /// group you are already in also succeeds — the API returns that group.
+    func redeem() async -> GroupDetail? {
+        guard canRedeem else { return nil }
+        
+        isRedeeming = true
+        errorMessage = nil
+        defer { isRedeeming = false }
+        
+        do {
+            return try await GroupService.shared.redeemInvite(code: code)
+        } catch {
+            errorMessage = Self.message(for: error)
+            return nil
+        }
+    }
+    
+    private static func message(for error: Error) -> String {
+        guard case APIError.httpError(let status) = error else {
+            return error.localizedDescription
+        }
+        switch status {
+        case 404: return "That invite code isn't valid."
+        case 410: return "That invite has expired. Ask for a new one."
+        case 409: return "That invite has no uses left. Ask for a new one."
+        case 429: return "Too many attempts. Wait a minute and try again."
+        default: return "Something went wrong (\(status)). Try again."
+        }
+    }
+}

--- a/Splitty/Splitty/Views/GroupFormSheet.swift
+++ b/Splitty/Splitty/Views/GroupFormSheet.swift
@@ -1,0 +1,71 @@
+//
+//  GroupFormSheet.swift
+//  Splitty
+//
+
+import SwiftUI
+
+struct GroupFormSheet: View {
+    @StateObject private var viewModel: GroupFormViewModel
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var nameFocused: Bool
+    
+    private let onSaved: (Int) -> Void
+    
+    init(group: GroupDetail? = nil, onSaved: @escaping (Int) -> Void) {
+        _viewModel = StateObject(wrappedValue: GroupFormViewModel(
+            existingGroupId: group?.id,
+            name: group?.name ?? "",
+            description: group?.description ?? ""
+        ))
+        self.onSaved = onSaved
+    }
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Name", text: $viewModel.name)
+                        .focused($nameFocused)
+                    TextField("Description (optional)", text: $viewModel.description, axis: .vertical)
+                        .lineLimit(1...3)
+                }
+                
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle(viewModel.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.isSaving {
+                        ProgressView()
+                    } else {
+                        Button(viewModel.isEditing ? "Save" : "Create") {
+                            Task {
+                                if let groupId = await viewModel.save() {
+                                    onSaved(groupId)
+                                    dismiss()
+                                }
+                            }
+                        }
+                        .disabled(!viewModel.canSave)
+                    }
+                }
+            }
+            .onAppear { nameFocused = true }
+        }
+    }
+}
+
+#Preview {
+    GroupFormSheet { _ in }
+}

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -11,54 +11,59 @@ struct GroupView: View {
     let groupId: Int
     @StateObject private var viewModel = GroupViewModel()
     @Environment(\.dismiss) private var dismiss
+    @State private var showingEditSheet = false
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color("background")
-                    .ignoresSafeArea()
-                
-                if viewModel.isLoading {
-                    ProgressView("Loading...")
-                        .foregroundColor(Color("foreground"))
-                } else {
-                    ScrollView {
-                        VStack(spacing: 0) {
-                            // Header Section
-                            headerSection
-                            
-                            // Action Buttons
-                            actionButtonsSection
-                            
-                            // Expenses List
-                            expensesList
-                        }
+        ZStack {
+            Color("background")
+                .ignoresSafeArea()
+            
+            if viewModel.isLoading {
+                ProgressView("Loading...")
+                    .foregroundColor(Color("foreground"))
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // Header Section
+                        headerSection
+                        
+                        // Action Buttons
+                        actionButtonsSection
+                        
+                        // Expenses List
+                        expensesList
                     }
                 }
             }
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "chevron.left")
-                            Text("Groups")
-                        }
-                        .foregroundColor(Color("foreground"))
-                    }
-                }
-                
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Edit") {
-                        // TODO: Edit action
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { dismiss() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Groups")
                     }
                     .foregroundColor(Color("foreground"))
                 }
             }
+            
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit") {
+                    showingEditSheet = true
+                }
+                .foregroundColor(Color("foreground"))
+                .disabled(viewModel.group == nil)
+            }
         }
-        .onAppear {
-            viewModel.loadGroupData(groupId: groupId)
+        .sheet(isPresented: $showingEditSheet) {
+            GroupFormSheet(group: viewModel.group) { _ in
+                Task { await viewModel.loadGroupData(groupId: groupId) }
+            }
+        }
+        .task {
+            await viewModel.loadGroupData(groupId: groupId)
         }
     }
     

--- a/Splitty/Splitty/Views/GroupsView.swift
+++ b/Splitty/Splitty/Views/GroupsView.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 struct GroupsView: View {
     @StateObject private var viewModel = GroupsViewModel()
+    @State private var path: [Int] = []
+    @State private var showingCreateSheet = false
+    @State private var showingJoinSheet = false
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             VStack(alignment: .leading) {
 
                 HStack {
@@ -24,6 +27,16 @@ struct GroupsView: View {
                     }
                     
                     Spacer()
+                    
+                    Menu {
+                        Button("New group") { showingCreateSheet = true }
+                        Button("Join with code") { showingJoinSheet = true }
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.title2)
+                            .foregroundColor(Color("foreground"))
+                    }
+                    .padding(.trailing, 12)
                     
                     Avatar()
                 }
@@ -38,15 +51,40 @@ struct GroupsView: View {
                     }
                 }
                 .refreshable {
-                    await viewModel.loadGroupsAsync()
-                }
-                .onAppear {
-                    viewModel.loadGroups()
+                    await viewModel.loadGroups()
                 }
                 
                 Spacer()
             }
             .background(Color("background").ignoresSafeArea())
+            .navigationDestination(for: Int.self) { groupId in
+                GroupView(groupId: groupId)
+            }
+            .task {
+                await viewModel.loadGroups()
+            }
+            .onChange(of: path) { _, newPath in
+                // Coming back from a group picks up any edit made in there.
+                if newPath.isEmpty {
+                    Task { await viewModel.loadGroups() }
+                }
+            }
+            .sheet(isPresented: $showingCreateSheet) {
+                GroupFormSheet { groupId in
+                    Task {
+                        await viewModel.loadGroups()
+                        path.append(groupId)
+                    }
+                }
+            }
+            .sheet(isPresented: $showingJoinSheet) {
+                JoinGroupSheet { group in
+                    Task {
+                        await viewModel.loadGroups()
+                        path.append(group.id)
+                    }
+                }
+            }
         }
     }
 }

--- a/Splitty/Splitty/Views/JoinGroupSheet.swift
+++ b/Splitty/Splitty/Views/JoinGroupSheet.swift
@@ -1,0 +1,66 @@
+//
+//  JoinGroupSheet.swift
+//  Splitty
+//
+
+import SwiftUI
+
+struct JoinGroupSheet: View {
+    @StateObject private var viewModel = JoinGroupViewModel()
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var codeFocused: Bool
+    
+    /// Called with the joined group so the caller can refresh and navigate.
+    let onJoined: (GroupDetail) -> Void
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Invite code", text: $viewModel.code)
+                        .focused($codeFocused)
+                        .textInputAutocapitalization(.characters)
+                        .autocorrectionDisabled()
+                        .font(.system(.title2, design: .monospaced))
+                } footer: {
+                    Text("Ask a group member for their \(JoinGroupViewModel.codeLength)-character invite code.")
+                }
+                
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("Join with code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.isRedeeming {
+                        ProgressView()
+                    } else {
+                        Button("Join") {
+                            Task {
+                                if let group = await viewModel.redeem() {
+                                    onJoined(group)
+                                    dismiss()
+                                }
+                            }
+                        }
+                        .disabled(!viewModel.canRedeem)
+                    }
+                }
+            }
+            .onAppear { codeFocused = true }
+        }
+    }
+}
+
+#Preview {
+    JoinGroupSheet { _ in }
+}


### PR DESCRIPTION
Closes #16.

## What

- `+` menu in the `GroupsView` header (left of the avatar) with "New group" / "Join with code".
- One sheet, `GroupFormSheet`, serves both create and edit, driven by an optional existing group. Name required, description optional.
- The inert "Edit" button in the `GroupView` toolbar is wired to that same sheet.
- `JoinGroupSheet` takes a 6-character code, uppercased as typed and filtered to `A-Z0-9`. On success the list refreshes and the joined group is pushed.

## Backend mismatches found while building

Two would have failed on first run:

- `POST /group` and `PUT /group/{id}` return the **`Group` entity**, not the `GroupDTO` the list endpoints return — no `netBalance`, and `members` are membership rows rather than `MemberDTO`. Decoding into the client `Group` struct threw on every successful create. They now decode a narrow `GroupMutationResponse` and the list refetch supplies real data.
- `GroupDTO.Description` is nullable but `description` was non-optional on the client, so a group created without a description broke the entire list decode. Optional on both group models now.

The issue also states redemption failures come back as `400` and that the API cannot distinguish a wrong code from a used-up one. It can: `InviteController` returns 404 / 410 / 409, and the rate limiter returns 429. Copy follows the real codes. Being already a member is a `200` that returns the group, so it navigates rather than erroring.

## Navigation

Redemption has to push a group the user just joined, which the old `NavigationLink(destination:)` inside `GroupCard` could not express. `GroupsView` now owns a `NavigationStack(path: [Int])` with `navigationDestination(for: Int.self)`, `GroupCard` uses `NavigationLink(value:)`, and `GroupView` no longer nests its own stack. Popping back reloads the list so an edit made inside a group shows up.

## Also

Per X2, the completion-handler duplicates in `GroupService` are gone and `GroupsViewModel` / `GroupViewModel` moved to async — the latter drops a `DispatchGroup` for `async let`.

Left alone deliberately: the hardcoded `"Overall, you are owed $320.43"` placeholder, which needs the balances epic.

## Testing

Builds clean for the iPhone 17 Pro simulator. Verified by hand against a seeded API: create, edit, successful join, and each redemption failure path — expired (410), exhausted (409), unknown code (404).