### PR TITLE
OAuth sign-in: iOS (Google Sign-In, new login screen, app logo)

### DIFF
--- a/Splitty-API/Splitty.API/DotEnvFile.cs
+++ b/Splitty-API/Splitty.API/DotEnvFile.cs
@@ -1,0 +1,57 @@
+namespace Splitty.API;
+
+/// Loads the repo-root `.env` into the process environment so that a plain `dotnet run`
+/// or an IDE run configuration sees the same secrets `docker compose` gets from
+/// `env_file`. Without this the API starts with an empty signing key and fails on the
+/// first request instead of at startup.
+public static class DotEnvFile
+{
+    /// Walks up from the content root looking for `<dir>/.env`. Values already present in
+    /// the environment win, so an explicit export or a compose variable is never
+    /// overwritten by the file.
+    public static void Load(string startDirectory)
+    {
+        var directory = new DirectoryInfo(startDirectory);
+
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, ".env");
+
+            if (File.Exists(candidate))
+            {
+                Apply(candidate);
+                return;
+            }
+
+            directory = directory.Parent;
+        }
+    }
+
+    private static void Apply(string path)
+    {
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            var separator = line.IndexOf('=');
+
+            if (separator <= 0) continue;
+
+            var key = line[..separator].Trim();
+            var value = line[(separator + 1)..].Trim();
+
+            // Quoting is how a value keeps leading or trailing spaces; strip the quotes.
+            if (value.Length >= 2 &&
+                ((value[0] == '"' && value[^1] == '"') || (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value[1..^1];
+            }
+
+            if (Environment.GetEnvironmentVariable(key) is not null) continue;
+
+            Environment.SetEnvironmentVariable(key, value);
+        }
+    }
+}

--- a/Splitty-API/Splitty.API/Program.cs
+++ b/Splitty-API/Splitty.API/Program.cs
@@ -22,6 +22,10 @@ using Splitty.Service;
 using Splitty.Service.Interfaces;
 using Scalar.AspNetCore;
 
+// Before CreateBuilder, so the file lands in the environment ahead of the configuration
+// providers reading it. `docker compose` supplies the same values through `env_file`.
+DotEnvFile.Load(Directory.GetCurrentDirectory());
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.AddConsole();
 
@@ -42,9 +46,20 @@ builder.Services.AddControllers(options =>
     });
 // Secrets arrive as Jwt__SecretKey / Google__ClientId / Google__ClientSecret from .env.
 // Failing here beats minting tokens signed with "" or exchanging codes as an empty client.
+//
+// The signing key is checked in every environment, Development included: an empty key
+// throws inside the JwtBearer handler, which runs per request, so skipping the check
+// turns a config fault into a 400 on every route rather than a startup crash.
+if (string.IsNullOrWhiteSpace(builder.Configuration["Jwt:SecretKey"]))
+{
+    throw new InvalidOperationException("Configuration 'Jwt:SecretKey' is required.");
+}
+
+// Google credentials only matter to the real token exchanger, which the test suite
+// replaces with a fake, so these stay scoped to non-Development hosts.
 if (!builder.Environment.IsDevelopment())
 {
-    foreach (var key in new[] { "Jwt:SecretKey", "Google:ClientId", "Google:ClientSecret" })
+    foreach (var key in new[] { "Google:ClientId", "Google:ClientSecret" })
     {
         if (string.IsNullOrWhiteSpace(builder.Configuration[key]))
         {

--- a/Splitty/Splitty.xcodeproj/project.pbxproj
+++ b/Splitty/Splitty.xcodeproj/project.pbxproj
@@ -60,11 +60,16 @@
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
+/* Begin PBXBuildFile section */
+		09A1B2C43001DB6E0066C78D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 09A1B2C33001DB6E0066C78D /* GoogleSignIn */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		0955FC842D5584AC002471A6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09A1B2C43001DB6E0066C78D /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +130,7 @@
 			);
 			name = Splitty;
 			packageProductDependencies = (
+				09A1B2C33001DB6E0066C78D /* GoogleSignIn */,
 			);
 			productName = Splitty;
 			productReference = 0955FC872D5584AC002471A6 /* Splitty.app */;
@@ -210,6 +216,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				09989C362E8E14FB0084CD00 /* XCRemoteSwiftPackageReference "keychain-swift" */,
+				091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0955FC882D5584AC002471A6 /* Products */;
@@ -577,7 +584,23 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCSwiftPackageProductDependency section */
+		09A1B2C33001DB6E0066C78D /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+/* End XCSwiftPackageProductDependency section */
+
 /* Begin XCRemoteSwiftPackageReference section */
+		091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.2.0;
+			};
+		};
 		09989C362E8E14FB0084CD00 /* XCRemoteSwiftPackageReference "keychain-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/evgenyneu/keychain-swift.git";

--- a/Splitty/Splitty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Splitty/Splitty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,69 @@
 {
-  "originHash" : "61d0f8bddcbf3b93ae7ce1d42c4f6929e95bfcb66319ddeb36d0dda55337047e",
+  "originHash" : "631813dc17e6ddd7fd0d134bd6b0bed58fec6880f9231be39fb359b5d4a25e94",
   "pins" : [
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "a7caeda164dc5108bf4649472b28a5af65dc6f33",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "08d8dcecafb575f98879ffdbb8302c1b9ad65d19",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
     {
       "identity" : "keychain-swift",
       "kind" : "remoteSourceControl",
@@ -8,6 +71,15 @@
       "state" : {
         "revision" : "5e1b02b6a9dac2a759a1d5dbc175c86bd192a608",
         "version" : "24.0.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     }
   ],

--- a/Splitty/Splitty/Assets.xcassets/Logo.imageset/Contents.json
+++ b/Splitty/Splitty/Assets.xcassets/Logo.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "logo.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Splitty/Splitty/Assets.xcassets/Logo.imageset/logo.svg
+++ b/Splitty/Splitty/Assets.xcassets/Logo.imageset/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <g fill="none" stroke="#3B82F6" stroke-width="64">
+    <circle cx="384" cy="512" r="256"/>
+    <circle cx="640" cy="512" r="256"/>
+  </g>
+</svg>

--- a/Splitty/Splitty/Info.plist
+++ b/Splitty/Splitty/Info.plist
@@ -8,7 +8,7 @@
 	     App Store binary. Security comes from the bundle id plus the server-side code
 	     exchange, so these stay in plaintext and a fresh clone builds. -->
 	<key>GIDClientID</key>
-	<string>978511957932-9pj6toiu4cmo9842u73jbp3bgepp96h1.apps.googleusercontent.com</string>
+	<string>978511957932-8f4eqisf6kb01dr8d4ev8s1sgk8ntle5.apps.googleusercontent.com</string>
 	<!-- The Web client id, not the iOS one: this is the audience the API validates. -->
 	<key>GIDServerClientID</key>
 	<string>978511957932-q42ajkjue9hbn86t4caaogr7fda8ap6n.apps.googleusercontent.com</string>
@@ -17,7 +17,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.978511957932-9pj6toiu4cmo9842u73jbp3bgepp96h1</string>
+				<string>com.googleusercontent.apps.978511957932-8f4eqisf6kb01dr8d4ev8s1sgk8ntle5</string>
 			</array>
 		</dict>
 	</array>

--- a/Splitty/Splitty/Info.plist
+++ b/Splitty/Splitty/Info.plist
@@ -8,16 +8,16 @@
 	     App Store binary. Security comes from the bundle id plus the server-side code
 	     exchange, so these stay in plaintext and a fresh clone builds. -->
 	<key>GIDClientID</key>
-	<string>REPLACE_WITH_IOS_CLIENT_ID.apps.googleusercontent.com</string>
+	<string>978511957932-9pj6toiu4cmo9842u73jbp3bgepp96h1.apps.googleusercontent.com</string>
 	<!-- The Web client id, not the iOS one: this is the audience the API validates. -->
 	<key>GIDServerClientID</key>
-	<string>REPLACE_WITH_WEB_CLIENT_ID.apps.googleusercontent.com</string>
+	<string>978511957932-q42ajkjue9hbn86t4caaogr7fda8ap6n.apps.googleusercontent.com</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.REPLACE_WITH_IOS_CLIENT_ID</string>
+				<string>com.googleusercontent.apps.978511957932-9pj6toiu4cmo9842u73jbp3bgepp96h1</string>
 			</array>
 		</dict>
 	</array>

--- a/Splitty/Splitty/Info.plist
+++ b/Splitty/Splitty/Info.plist
@@ -4,6 +4,23 @@
 <dict>
 	<key>SplittyAPIBaseURL</key>
 	<string>$(SPLITTY_API_BASE_URL)</string>
+	<!-- A Google client id is a public identifier, not a secret: it ships inside every
+	     App Store binary. Security comes from the bundle id plus the server-side code
+	     exchange, so these stay in plaintext and a fresh clone builds. -->
+	<key>GIDClientID</key>
+	<string>REPLACE_WITH_IOS_CLIENT_ID.apps.googleusercontent.com</string>
+	<!-- The Web client id, not the iOS one: this is the audience the API validates. -->
+	<key>GIDServerClientID</key>
+	<string>REPLACE_WITH_WEB_CLIENT_ID.apps.googleusercontent.com</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.REPLACE_WITH_IOS_CLIENT_ID</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -95,15 +95,21 @@ class APIClient {
     }
     
     // MARK: - Authentication
-    func login(email: String, password: String) async throws -> LoginResponse {
-        let body = ["email": email, "password": password]
-        return try await request(endpoint: "/auth/login", method: .POST, body: body, requiresAuth: false)
+    /// Redeems a one-time Google auth code for a Splitty token. The exchange with Google
+    /// happens server-side, so no client secret is needed here.
+    func oauthGoogle(authCode: String) async throws -> LoginResponse {
+        let body = ["authCode": authCode]
+        return try await request(endpoint: "/oauth/google", method: .POST, body: body, requiresAuth: false)
     }
     
-    func register(name: String, email: String, password: String) async throws -> LoginResponse {
-        let body = ["name": name, "email": email, "password": password]
-        return try await request(endpoint: "/auth/register", method: .POST, body: body, requiresAuth: false)
+    #if DEBUG
+    /// Signs in as a seeded user with no credential. The route only exists on a
+    /// Development host, so this cannot reach a deployed API.
+    func devLogin(email: String) async throws -> LoginResponse {
+        let body = ["email": email]
+        return try await request(endpoint: "/auth/dev-login", method: .POST, body: body, requiresAuth: false)
     }
+    #endif
     
     // MARK: - Groups
     func getGroups() async throws -> [Group] {

--- a/Splitty/Splitty/Services/AuthService.swift
+++ b/Splitty/Splitty/Services/AuthService.swift
@@ -12,27 +12,31 @@ class AuthService {
     
     private init() {}
     
-    // MARK: - Login
-    func login(email: String, password: String) async throws -> User {
-        let response = try await APIClient.shared.login(email: email, password: password)
+    // MARK: - Sign in with Google
+    /// Throws `GoogleSignInError.cancelled` when the user dismisses the account picker.
+    func signInWithGoogle() async throws -> User {
+        let authCode = try await GoogleSignInService.shared.signIn()
+        let response = try await APIClient.shared.oauthGoogle(authCode: authCode)
         
         // Save token to keychain
         TokenManager.shared.saveToken(response.token)
         
-        print("✅ User logged in successfully: \(response.user.name)")
+        print("✅ User signed in with Google: \(response.user.name)")
         return response.user
     }
     
-    // MARK: - Register
-    func register(name: String, email: String, password: String) async throws -> User {
-        let response = try await APIClient.shared.register(name: name, email: email, password: password)
+    #if DEBUG
+    // MARK: - Dev sign in
+    func devSignIn(email: String) async throws -> User {
+        let response = try await APIClient.shared.devLogin(email: email)
         
         // Save token to keychain
         TokenManager.shared.saveToken(response.token)
         
-        print("✅ User registered successfully: \(response.user.name)")
+        print("✅ Dev sign-in as: \(response.user.name)")
         return response.user
     }
+    #endif
     
     // MARK: - Logout
     func logout() {

--- a/Splitty/Splitty/Services/GoogleSignInService.swift
+++ b/Splitty/Splitty/Services/GoogleSignInService.swift
@@ -1,0 +1,92 @@
+//
+//  GoogleSignInService.swift
+//  Splitty
+//
+//  Created by Snowye on 20/08/26.
+//
+
+import Foundation
+import GoogleSignIn
+import UIKit
+
+/// Wraps the Google SDK down to the one thing the API needs: a one-time `serverAuthCode`.
+///
+/// The app never holds a Google access or refresh token and there is no client secret on
+/// the device — the code is redeemed server-side by `POST /oauth/google`.
+///
+/// `GIDClientID` and `GIDServerClientID` are read straight out of `Info.plist` by the SDK,
+/// so there is no configuration step here.
+final class GoogleSignInService {
+    static let shared = GoogleSignInService()
+
+    private init() {}
+
+    /// Presents the Google account picker and returns the server auth code.
+    ///
+    /// Throws `GoogleSignInError.cancelled` when the user dismisses the sheet, so callers
+    /// can stay silent about a deliberate dismiss.
+    @MainActor
+    func signIn() async throws -> String {
+        guard let presenter = Self.topViewController() else {
+            throw GoogleSignInError.noPresenter
+        }
+
+        let result: GIDSignInResult
+        do {
+            result = try await withCheckedThrowingContinuation { continuation in
+                GIDSignIn.sharedInstance.signIn(withPresenting: presenter) { signInResult, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if let signInResult {
+                        continuation.resume(returning: signInResult)
+                    } else {
+                        continuation.resume(throwing: GoogleSignInError.failed)
+                    }
+                }
+            }
+        } catch {
+            if let signInError = error as? GIDSignInError, signInError.code == .canceled {
+                throw GoogleSignInError.cancelled
+            }
+            throw GoogleSignInError.failed
+        }
+
+        // Only present when `GIDServerClientID` is set; a nil code means the plist is wrong.
+        guard let authCode = result.serverAuthCode else {
+            throw GoogleSignInError.missingAuthCode
+        }
+
+        return authCode
+    }
+
+    /// Completes a sign-in redirect handed back to the app by the custom URL scheme.
+    @discardableResult
+    static func handle(_ url: URL) -> Bool {
+        GIDSignIn.sharedInstance.handle(url)
+    }
+
+    @MainActor
+    private static func topViewController() -> UIViewController? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+
+        guard var top = scene?.windows.first(where: \.isKeyWindow)?.rootViewController else {
+            return nil
+        }
+
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+
+        return top
+    }
+}
+
+enum GoogleSignInError: Error {
+    /// The user dismissed the account picker. Not surfaced to the user.
+    case cancelled
+    case noPresenter
+    case missingAuthCode
+    case failed
+}

--- a/Splitty/Splitty/SplittyApp.swift
+++ b/Splitty/Splitty/SplittyApp.swift
@@ -12,6 +12,10 @@ struct SplittyApp: App {
     var body: some Scene {
         WindowGroup {
             RootView()
+                // The Google SDK completes sign-in through the reversed-client-id scheme.
+                .onOpenURL { url in
+                    GoogleSignInService.handle(url)
+                }
         }
     }
 }

--- a/Splitty/Splitty/Views/LoginView.swift
+++ b/Splitty/Splitty/Views/LoginView.swift
@@ -8,51 +8,42 @@
 import SwiftUI
 
 struct LoginView: View {
-    @State private var email = ""
-    @State private var password = ""
     @State private var isLoading = false
     @State private var errorMessage = ""
     @StateObject private var authManager = AuthenticationManager.shared
-    
+
     var body: some View {
         ZStack {
             // Simple black background
             Color.black
                 .ignoresSafeArea()
-            
+
             VStack(spacing: 0) {
-                // Logo and Title Section
-                VStack(spacing: 20) {
-                    Spacer()
-                    
-                    Image(systemName: "dollarsign.circle.fill")
-                        .font(.system(size: 60))
-                        .foregroundColor(.white)
-                    
-                    Text("Hello.")
+                Spacer()
+
+                // Brand Section
+                VStack(spacing: 12) {
+                    Image("Logo")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 96, height: 96)
+
+                    Text("Splitty")
                         .font(.largeTitle)
-                        .fontWeight(.regular)
+                        .fontWeight(.semibold)
                         .foregroundColor(.white)
-                    
-                    Spacer()
-                    Spacer()
+
+                    // Says what the app is before it asks for an account.
+                    Text("Split expenses, settle up.")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.6))
                 }
-                
-                // Login Form
+
+                Spacer()
+                Spacer()
+
+                // Providers
                 VStack(spacing: 16) {
-                    VStack(spacing: 12) {
-                        TextField("Email", text: $email)
-                            .textFieldStyle(MinimalTextFieldStyle())
-                            .autocapitalization(.none)
-                            .keyboardType(.emailAddress)
-                            .textContentType(.emailAddress)
-                        
-                        SecureField("Password", text: $password)
-                            .textFieldStyle(MinimalTextFieldStyle())
-                            .textContentType(.password)
-                    }
-                    
-                    // Error Message
                     if !errorMessage.isEmpty {
                         Text(errorMessage)
                             .foregroundColor(.red)
@@ -60,18 +51,21 @@ struct LoginView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 20)
                     }
-                    
-                    // Login Button
+
                     Button {
-                        Task { await login() }
+                        Task { await signInWithGoogle() }
                     } label: {
-                        HStack {
+                        HStack(spacing: 10) {
                             if isLoading {
                                 ProgressView()
                                     .progressViewStyle(CircularProgressViewStyle(tint: .black))
                                     .scaleEffect(0.8)
                             } else {
-                                Text("Continue")
+                                GoogleMark()
+                                    .frame(width: 18, height: 18)
+
+                                // Google brand guidelines require this exact string.
+                                Text("Sign in with Google")
                                     .fontWeight(.medium)
                             }
                         }
@@ -81,77 +75,186 @@ struct LoginView: View {
                         .foregroundColor(.black)
                         .cornerRadius(25)
                     }
-                    .disabled(isLoading || email.isEmpty || password.isEmpty)
-                    .opacity((email.isEmpty || password.isEmpty) ? 0.6 : 1.0)
+                    .disabled(isLoading)
                     .padding(.horizontal, 20)
-                    .padding(.top, 10)
-                    
-                    // Mock User Button (Temporary)
-                    Button {
-                        Task { await loginWithMockUser() }
-                    } label: {
-                        HStack {
-                            Image(systemName: "person.circle")
-                            Text("Login as John")
-                                .fontWeight(.medium)
+
+                    // Placeholder until Apple credentials exist. Sign in with Apple is
+                    // mandatory for App Store review once any third-party provider ships,
+                    // so this is a submission blocker, not a nice-to-have.
+                    VStack(spacing: 6) {
+                        Button {
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "apple.logo")
+                                Text("Sign in with Apple")
+                                    .fontWeight(.medium)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                            .background(Color.white)
+                            .foregroundColor(.black)
+                            .cornerRadius(25)
                         }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .background(Color.gray.opacity(0.2))
-                        .foregroundColor(.white)
-                        .cornerRadius(25)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 25)
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                        )
+                        .disabled(true)
+                        .opacity(0.4)
+
+                        Text("Coming soon")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.4))
                     }
                     .padding(.horizontal, 20)
-                    .padding(.top, 8)
+
+                    #if DEBUG
+                    DevSignInPicker(isLoading: $isLoading, errorMessage: $errorMessage)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 8)
+                    #endif
                 }
                 .padding(.bottom, 50)
             }
         }
     }
-    
+
     @MainActor
-    private func login() async {
+    private func signInWithGoogle() async {
         isLoading = true
         errorMessage = ""
         defer { isLoading = false }
-        
+
         do {
-            let user = try await AuthService.shared.login(email: email, password: password)
-            print("✅ Login successful for user: \(user.name)")
+            let user = try await AuthService.shared.signInWithGoogle()
+            print("✅ Sign-in successful for user: \(user.name)")
             authManager.login()
+        } catch GoogleSignInError.cancelled {
+            // Dismissing the sheet is deliberate; nothing to report.
         } catch {
-            errorMessage = "Login failed: \(error.localizedDescription)"
+            errorMessage = Self.message(for: error)
         }
     }
-    
-    @MainActor
-    private func loginWithMockUser() async {
-        email = "john@example.com"
-        password = "Test@123"
-        await login()
+
+    /// Never surfaces a raw `localizedDescription` from the SDK or a 500.
+    static func message(for error: Error) -> String {
+        if let signInError = error as? GoogleSignInError {
+            switch signInError {
+            case .missingAuthCode, .noPresenter:
+                return "Sign-in isn't set up correctly on this build."
+            case .cancelled, .failed:
+                return "Sign-in failed. Try again."
+            }
+        }
+
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .httpError(401):
+                return "Google couldn't verify that account. Try again."
+            case .httpError, .decodingError, .invalidResponse:
+                return "Something went wrong signing you in. Try again in a moment."
+            case .networkError:
+                return "Couldn't reach Splitty. Check your connection and try again."
+            default:
+                return "Sign-in isn't set up correctly on this build."
+            }
+        }
+
+        return "Sign-in failed. Try again."
     }
 }
 
-struct MinimalTextFieldStyle: TextFieldStyle {
-    func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
-            .padding(.horizontal, 20)
-            .padding(.vertical, 16)
-            .background(Color.gray.opacity(0.15))
+/// The Google "G" in its four brand colours, drawn rather than bundled so there is no
+/// image asset to keep in sync with the SDK.
+private struct GoogleMark: View {
+    var body: some View {
+        GeometryReader { geometry in
+            let size = min(geometry.size.width, geometry.size.height)
+
+            ZStack {
+                Circle()
+                    .trim(from: 0.0, to: 0.25)
+                    .stroke(Color(red: 0.92, green: 0.26, blue: 0.21), lineWidth: size * 0.22)
+                    .rotationEffect(.degrees(-90))
+                Circle()
+                    .trim(from: 0.25, to: 0.5)
+                    .stroke(Color(red: 0.98, green: 0.74, blue: 0.02), lineWidth: size * 0.22)
+                    .rotationEffect(.degrees(-90))
+                Circle()
+                    .trim(from: 0.5, to: 0.75)
+                    .stroke(Color(red: 0.20, green: 0.66, blue: 0.33), lineWidth: size * 0.22)
+                    .rotationEffect(.degrees(-90))
+                Circle()
+                    .trim(from: 0.75, to: 1.0)
+                    .stroke(Color(red: 0.26, green: 0.52, blue: 0.96), lineWidth: size * 0.22)
+                    .rotationEffect(.degrees(-90))
+
+                Rectangle()
+                    .fill(Color(red: 0.26, green: 0.52, blue: 0.96))
+                    .frame(width: size * 0.5, height: size * 0.22)
+                    .offset(x: size * 0.25, y: 0)
+            }
+            .frame(width: size, height: size)
+        }
+    }
+}
+
+#if DEBUG
+/// A picker rather than a single button: testing splits and balances means signing in as
+/// a *different* member of the same seeded group.
+private struct DevSignInPicker: View {
+    private static let seededEmails = [
+        "john@example.com",
+        "jane@example.com",
+        "bob@example.com",
+        "alice@example.com",
+        "charlie@example.com",
+        "eva@example.com"
+    ]
+
+    @Binding var isLoading: Bool
+    @Binding var errorMessage: String
+    @StateObject private var authManager = AuthenticationManager.shared
+
+    var body: some View {
+        Menu {
+            ForEach(Self.seededEmails, id: \.self) { email in
+                Button(email) {
+                    Task { await devSignIn(email: email) }
+                }
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "hammer")
+                Text("Dev sign in")
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(Color.gray.opacity(0.2))
             .foregroundColor(.white)
             .cornerRadius(25)
             .overlay(
                 RoundedRectangle(cornerRadius: 25)
                     .stroke(Color.gray.opacity(0.3), lineWidth: 1)
             )
-            .padding(.horizontal, 20)
+        }
+        .disabled(isLoading)
+    }
+
+    @MainActor
+    private func devSignIn(email: String) async {
+        isLoading = true
+        errorMessage = ""
+        defer { isLoading = false }
+
+        do {
+            let user = try await AuthService.shared.devSignIn(email: email)
+            print("✅ Dev sign-in successful for user: \(user.name)")
+            authManager.login()
+        } catch {
+            errorMessage = LoginView.message(for: error)
+        }
     }
 }
- 
+#endif
+
 #Preview {
     LoginView()
 }


### PR DESCRIPTION
Closes #27. Part 2 of 2 for #23 — the iOS side of OAuth-only sign-in.

## What changed

The login screen loses email, password, and the hardcoded "Login as John" button. What's left is the logo, two provider buttons, and a debug-only user picker.

`GoogleSignInService` wraps the SDK down to one thing: a one-time `serverAuthCode`. The app never holds a Google access or refresh token and carries no client secret — `POST /oauth/google` redeems the code server-side.

Cancelling the account picker is silent (D5): dismissing the sheet is deliberate, and an error toast for a deliberate dismiss is user-hostile. Every other failure maps through `LoginView.message(for:)` to a human sentence rather than a raw `localizedDescription` (D6).

Apple ships as a disabled placeholder at 40% opacity in the same 50pt pill, so the two read as a pair. **Sign in with Apple is mandatory for App Store review once any third-party provider ships** — this is a submission blocker for later, not just a TODO.

The DEBUG picker covers all six seeded emails rather than one button, because testing splits and balances means signing in as a *different* member of the same group (D7).

### Deleted

`APIClient.login`, `APIClient.register`, `AuthService.login`, `AuthService.register`, `MinimalTextFieldStyle`, the email and password fields, the mock-user button.

## Two fixes found while testing

**The API never loaded `.env` outside Docker.** `docker-compose.yml` passes it via `env_file`; a plain `dotnet run` or an IDE run configuration got nothing, so `Jwt:SecretKey` stayed `""` from `appsettings.json`. An empty key throws inside the JwtBearer handler, which runs per request *before* routing — so every route answered 400, `[AllowAnonymous]` ones included. Sign-in failed with a message about the request rather than about configuration.

`DotEnvFile` walks up from the content root and loads the first `.env` it finds, leaving any variable already in the environment alone so an explicit export or a compose value still wins.

The signing-key check no longer skips Development, per review feedback on #26: a missing key is a startup crash naming the setting instead of a 400 on every route. Google credentials keep their non-Development scope — only the real token exchanger needs them, and the suite fakes it.

**`GIDClientID` was pointing at a Web client.** Google refuses custom-scheme redirects for WEB clients: *"Custom scheme URIs are not allowed for 'WEB' client type."* Replaced with a real iOS client registered against `com.snowye.Splitty`. `GIDServerClientID` is unchanged — the audience the API validates is still the Web client.

## Notes

Client ids are committed in plaintext (D3). A Google client id is a public identifier, not a secret: it ships inside every App Store binary and `strings` will read it out. Security comes from the bundle id plus the server-side code exchange. Hiding it behind build settings protects nothing and breaks a fresh clone.

`SplittyTests/` is untouched — coverage for this epic lives on the API side. `dotnet test` is 39/39; the app builds clean for iOS Simulator.

## Follow-ups worth filing

- `TokenManager.isTokenValid()` only checks that the token has three dot-separated parts — it never decodes `exp`. With a 30-day JWT, an expired token passes and the app eats a 401 on the first request instead of showing the login screen.
- A config fault surfacing as HTTP 400 is wrong regardless of this fix. `GlobalExceptionHandlingMiddleware` turned an empty-signing-key crash into a 400, which sent me looking at the request body first.
- `appsettings.json` pins `Kestrel:EndPoints:Http:Url` to `0.0.0.0:8080`, silently overriding `ASPNETCORE_URLS` and both `launchSettings.json` profiles, which claim 5122/7083.