### PR TITLE
API: single-expense read, expense/settlement deletes, settlement edit, expense date

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,22 @@ repositories use **primary constructors** for injection — match that style.
 accepts and stores absolute per-user amounts and nothing else, so a mode exists only for as
 long as it takes the client to turn it into numbers. Reopening an expense cannot recover how
 it was originally split, and searching the backend for the term finds nothing by design.
+This was re-examined when the expense sheet was designed and deliberately kept: the client
+infers *equal* when every stored amount matches within a cent, and *custom* otherwise.
+Persisting the mode is a follow-up, and would reverse this.
+
+**Expense date** is `Expense.Date`, nullable, client-supplied, and may be in the future.
+`CreatedAt` next to it is the audit timestamp — server-set, never accepted from a client.
+Rows predating the column have no `Date`, so every reader that orders or groups expenses uses
+`Date ?? CreatedAt`, newest first.
+
+**Settlements are mutated through `/group/{groupId}/settlements/{expenseId}`**, never through
+the expense routes, even though a settlement is an `Expense` row. The expense `PUT`/`DELETE`
+refuse `Payment` rows rather than branching on `Type`. The settlement edit rebuilds both
+splits from the new amount and re-applies the cap of invariant 5 with the settlement's *own*
+contribution excluded — the stored balance already counts it, so a cap read raw would reject
+even re-saving the amount already there. See
+`docs/adr/0001-settlements-have-their-own-routes.md`.
 
 **Settle direction** is always caller-as-debtor. `POST /settle` records *the caller* paying
 the peer, so "who can settle a debt" has exactly one answer: the person who owes it. There is
@@ -86,6 +102,30 @@ These are the rules the domain actually depends on:
    than a live aggregate, which is deliberate: an over-tight cap is a retryable `400`, not a
    wrong number. The consequence is that a group whose balances the worker has not written
    yet caps at zero and rejects every settlement.
+
+## Language
+
+Terms that mean something specific here, and the words to avoid for them.
+
+**Settlement**:
+A repayment recorded between two members, stored as an `Expense` with `Type = Payment`.
+_Avoid_: refund, transfer, payback
+
+**Participant**:
+A member carrying a split row on an expense. Distinct from the payer, who need not be one.
+_Avoid_: member (when talking about a single expense)
+
+**Split mode**:
+How the client derived the per-user amounts: *equal* or *custom*. Never leaves the client.
+_Avoid_: split type, division method
+
+**Preset**:
+A named starting point on the split screen that fills in payer and mode in one tap.
+_Avoid_: template, shortcut
+
+**Custom split**:
+Per-person amounts typed by hand, which must sum exactly to the total.
+_Avoid_: exact split, manual mode
 
 ## Balance recomputation
 

--- a/Splitty-API/Splitty.API.Tests/ApiClient.cs
+++ b/Splitty-API/Splitty.API.Tests/ApiClient.cs
@@ -82,6 +82,27 @@ public sealed class ApiClient
     public Task<HttpResponseMessage> UpdateExpenseAsync(int groupId, int expenseId, object body) =>
         _http.PutAsJsonAsync($"/group/{groupId}/expenses/{expenseId}", body);
 
+    public Task<HttpResponseMessage> GetExpenseAsync(int groupId, int expenseId) =>
+        _http.GetAsync($"/group/{groupId}/expenses/{expenseId}");
+
+    public Task<HttpResponseMessage> GetExpensesAsync(int groupId) =>
+        _http.GetAsync($"/group/{groupId}/expenses");
+
+    public Task<HttpResponseMessage> DeleteExpenseAsync(int groupId, int expenseId) =>
+        _http.DeleteAsync($"/group/{groupId}/expenses/{expenseId}");
+
+    public Task<HttpResponseMessage> UpdateSettlementAsync(int groupId, int expenseId, object body) =>
+        _http.PutAsJsonAsync($"/group/{groupId}/settlements/{expenseId}", body);
+
+    public Task<HttpResponseMessage> DeleteSettlementAsync(int groupId, int expenseId) =>
+        _http.DeleteAsync($"/group/{groupId}/settlements/{expenseId}");
+
+    public async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+    }
+
     public Task<HttpResponseMessage> RequestSummaryRefreshAsync(int groupId) =>
         _http.PostAsync($"/group/{groupId}/expenses/summary", null);
 

--- a/Splitty-API/Splitty.API.Tests/BalanceServiceDecorator.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceServiceDecorator.cs
@@ -17,4 +17,10 @@ public abstract class BalanceServiceDecorator(IBalanceService inner) : IBalanceS
 
     public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
         inner.SettleUp(groupId, userId, peerId, amount);
+
+    public Task UpdateSettlement(int groupId, int expenseId, int userId, decimal amount, DateTime? date) =>
+        inner.UpdateSettlement(groupId, expenseId, userId, amount, date);
+
+    public Task DeleteSettlement(int groupId, int expenseId, int userId) =>
+        inner.DeleteSettlement(groupId, expenseId, userId);
 }

--- a/Splitty-API/Splitty.API.Tests/ExpenseDateTests.cs
+++ b/Splitty-API/Splitty.API.Tests/ExpenseDateTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// The date the user says an expense happened on, which is not the audit timestamp. Rows
+/// without one — everything written before the column existed — read as <c>CreatedAt</c>.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class ExpenseDateTests(ApiFactory factory)
+{
+    private static readonly DateTime March = new(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private Task<DateTime?> StoredDateAsync(int expenseId) =>
+        factory.UseDbAsync(db => db.Expense.Where(e => e.Id == expenseId).Select(e => e.Date).FirstAsync());
+
+    [Fact]
+    public async Task A_date_supplied_on_create_is_stored_and_returned()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: March);
+
+        Assert.Equal(March, await StoredDateAsync(expenseId));
+
+        var body = await group.Guest.ReadJsonAsync(await group.Guest.GetExpenseAsync(group.Id, expenseId));
+        Assert.Equal(March, body.GetProperty("date").GetDateTime());
+    }
+
+    [Fact]
+    public async Task An_omitted_date_is_left_null_rather_than_guessed()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        Assert.Null(await StoredDateAsync(expenseId));
+    }
+
+    [Fact]
+    public async Task A_future_date_is_accepted()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var future = DateTime.UtcNow.AddYears(1);
+
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: future);
+
+        Assert.Equal(future, await StoredDateAsync(expenseId));
+    }
+
+    [Fact]
+    public async Task A_date_can_be_changed_by_an_update()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: March);
+        var moved = March.AddDays(9);
+
+        (await group.Guest.UpdateExpenseAsync(group.Id, expenseId, new { date = moved }))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal(moved, await StoredDateAsync(expenseId));
+    }
+
+    [Fact]
+    public async Task An_update_that_omits_the_date_leaves_it_alone()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: March);
+
+        (await group.Guest.UpdateExpenseAsync(group.Id, expenseId, new { description = "Lunch" }))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal(March, await StoredDateAsync(expenseId));
+    }
+
+    /// <summary>
+    /// <c>CreatedAt</c> is the audit timestamp and stays server-set: a client that supplies
+    /// one is writing to a field the request shape does not have.
+    /// </summary>
+    [Fact]
+    public async Task A_client_supplied_created_at_is_ignored()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var before = DateTime.UtcNow.AddSeconds(-5);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, new
+        {
+            paidBy = group.OwnerId,
+            amount = 20m,
+            description = "Dinner",
+            createdAt = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            splits = new[]
+            {
+                new { userId = group.OwnerId, amount = 10m },
+                new { userId = group.GuestId, amount = 10m }
+            }
+        });
+
+        var body = await group.Owner.ReadJsonAsync(response);
+        Assert.True(body.GetProperty("createdAt").GetDateTime() >= before);
+    }
+
+    /// <summary>
+    /// Ordering keys off the user's date where there is one and the audit timestamp where
+    /// there is not, so a backdated expense sorts under its date and not its insert order.
+    /// </summary>
+    [Fact]
+    public async Task The_list_is_ordered_newest_first_by_date_falling_back_to_created_at()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var backdated = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: March);
+        var undated = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        var recent = await group.CreateExpenseAsync(amount: 20m, share: 10m, date: DateTime.UtcNow.AddDays(1));
+
+        var body = await group.Guest.ReadJsonAsync(await group.Guest.GetExpensesAsync(group.Id));
+        var ids = body.EnumerateArray().Select(e => e.GetProperty("id").GetInt32()).ToList();
+
+        Assert.Equal(new[] { recent, undated, backdated }, ids);
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/ExpenseReadAndDeleteTests.cs
+++ b/Splitty-API/Splitty.API.Tests/ExpenseReadAndDeleteTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using Splitty.Domain.Entities;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Reading and deleting a single expense. Both are group sub-resources, so both answer a
+/// non-member with 403 (invariant 3), and the delete leaves balances that no longer follow
+/// from the surviving rows until a recomputation runs (invariant 1).
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class ExpenseReadAndDeleteTests(ApiFactory factory)
+{
+    private async Task<ApiClient> StrangerAsync()
+    {
+        var user = await ApiClient.Create(factory).SignInAsync(name: "Stranger");
+        return ApiClient.Create(factory, user.Token);
+    }
+
+    [Fact]
+    public async Task An_expense_can_be_read_one_at_a_time()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        var body = await group.Guest.ReadJsonAsync(await group.Guest.GetExpenseAsync(group.Id, expenseId));
+
+        Assert.Equal(expenseId, body.GetProperty("id").GetInt32());
+        Assert.Equal(20m, body.GetProperty("amount").GetDecimal());
+        Assert.Equal(2, body.GetProperty("splits").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Reading_an_expense_of_another_group_is_not_found()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var other = await GroupFixture.CreateAsync(factory);
+        var expenseId = await other.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        // The caller is a member of the group in the path, so this is a lookup failure and
+        // not an authorization one — the expense simply is not in that group.
+        var response = await group.Owner.GetExpenseAsync(group.Id, expenseId);
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task A_non_member_can_neither_read_nor_delete_an_expense()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        var stranger = await StrangerAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await stranger.GetExpenseAsync(group.Id, expenseId)).StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, (await stranger.DeleteExpenseAsync(group.Id, expenseId)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Deleting_an_expense_removes_it_and_the_debt_it_created()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+
+        var response = await group.Guest.DeleteExpenseAsync(group.Id, expenseId);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, (await group.Guest.GetExpenseAsync(group.Id, expenseId)).StatusCode);
+        Assert.Equal(0m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    [Fact]
+    public async Task Deleting_an_expense_takes_its_splits_with_it()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        (await group.Owner.DeleteExpenseAsync(group.Id, expenseId)).EnsureSuccessStatusCode();
+
+        Assert.Empty(await factory.UseDbAsync(db => db.ExpenseSplit
+            .Where(s => s.ExpenseId == expenseId)
+            .ToListAsync()));
+    }
+
+    /// <summary>
+    /// The route refuses settlements outright rather than branching on <c>Type</c>, per
+    /// docs/adr/0001-settlements-have-their-own-routes.md.
+    /// </summary>
+    [Fact]
+    public async Task The_expense_delete_route_refuses_a_settlement()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+        var settlementId = await group.SettleAsync(6m);
+
+        var response = await group.Guest.DeleteExpenseAsync(group.Id, settlementId);
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+        Assert.NotNull(await factory.UseDbAsync(db => db.Expense.FirstOrDefaultAsync(e => e.Id == settlementId)));
+    }
+
+    /// <summary>
+    /// A settlement's splits are rebuilt from its amount and capped, neither of which the
+    /// expense edit path does — so it refuses them too, and the cap has one home.
+    /// </summary>
+    [Fact]
+    public async Task The_expense_edit_route_refuses_a_settlement()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+        var settlementId = await group.SettleAsync(6m);
+
+        var response = await group.Guest.UpdateExpenseAsync(group.Id, settlementId, new { amount = 999m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+
+        var amount = await factory.UseDbAsync(db => db.Expense
+            .Where(e => e.Id == settlementId)
+            .Select(e => e.Amount)
+            .FirstAsync());
+        Assert.Equal(6m, amount);
+    }
+
+    [Fact]
+    public async Task Deleting_an_expense_twice_is_not_found_the_second_time()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        (await group.Owner.DeleteExpenseAsync(group.Id, expenseId)).EnsureSuccessStatusCode();
+        var second = await group.Owner.DeleteExpenseAsync(group.Id, expenseId);
+
+        await ErrorResponseAssertions.AssertErrorAsync(second, HttpStatusCode.NotFound);
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/GroupFixture.cs
+++ b/Splitty-API/Splitty.API.Tests/GroupFixture.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Splitty.Domain.Entities;
 using Splitty.Infrastructure;
@@ -61,13 +62,14 @@ public sealed class GroupFixture
         return new GroupFixture(factory, groupId, owner, ownerUser.Id, guest, guestUser.Id, guestUser.Token);
     }
 
-    public async Task<int> CreateExpenseAsync(decimal amount, decimal share)
+    public async Task<int> CreateExpenseAsync(decimal amount, decimal share, DateTime? date = null)
     {
         var response = await Owner.CreateExpenseAsync(Id, new
         {
             paidBy = OwnerId,
             amount,
             description = "Dinner",
+            date,
             splits = new[]
             {
                 new { userId = OwnerId, amount = share },
@@ -78,6 +80,21 @@ public sealed class GroupFixture
 
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
         return body.GetProperty("id").GetInt32();
+    }
+
+    /// <summary>
+    /// The id of the settlement the guest just recorded — the settle route answers with no
+    /// body, and every settlement assertion needs a row to point at.
+    /// </summary>
+    public async Task<int> SettleAsync(decimal amount)
+    {
+        (await Guest.SettleUpAsync(Id, new { withUserId = OwnerId, amount })).EnsureSuccessStatusCode();
+
+        return await _factory.UseDbAsync(db => db.Expense
+            .Where(e => e.GroupId == Id && e.Type == ExpenseType.Payment)
+            .OrderByDescending(e => e.Id)
+            .Select(e => e.Id)
+            .FirstAsync());
     }
 
     /// <summary>

--- a/Splitty-API/Splitty.API.Tests/SettlementEditTests.cs
+++ b/Splitty-API/Splitty.API.Tests/SettlementEditTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using Splitty.Domain.Entities;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Editing and deleting a settlement through its own routes. The edit re-applies the cap of
+/// invariant 5 against a balance that already counts the row being edited, which is the one
+/// thing this path can get wrong without any test noticing.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class SettlementEditTests(ApiFactory factory)
+{
+    /// The owner pays 2x, so the guest owes x and settles part of it.
+    private async Task<(GroupFixture Group, int SettlementId)> SettledAsync(decimal owed, decimal settled)
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+
+        await group.CreateExpenseAsync(amount: owed * 2, share: owed);
+        await factory.WaitForProcessedAsync();
+
+        var settlementId = await group.SettleAsync(settled);
+        await factory.WaitForProcessedAsync();
+
+        return (group, settlementId);
+    }
+
+    [Fact]
+    public async Task Lowering_a_settlement_puts_the_difference_back_on_the_debt()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 10m);
+
+        var response = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 4m });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+        Assert.Equal(-6m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    /// <summary>
+    /// The regression the cap exists to avoid: a fully settled debt reads as zero, so an
+    /// edit measured against the raw balance would reject even the amount already stored.
+    /// </summary>
+    [Fact]
+    public async Task Re_saving_a_settlement_at_its_current_amount_is_accepted()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 10m);
+
+        var response = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 10m });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+        Assert.Equal(0m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    [Fact]
+    public async Task Raising_a_settlement_past_the_debt_is_rejected()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+
+        var response = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 10.01m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Raising_a_settlement_up_to_the_debt_is_accepted()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+
+        var response = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 10m });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+        Assert.Equal(0m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    /// <summary>
+    /// The replay reads splits and never reads <c>Amount</c>, so an edit that moved one and
+    /// not the other would change the number users see and move no money.
+    /// </summary>
+    [Fact]
+    public async Task An_edit_rebuilds_both_splits_from_the_new_amount()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+
+        (await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 7m }))
+            .EnsureSuccessStatusCode();
+
+        var splits = await factory.UseDbAsync(db => db.ExpenseSplit
+            .Where(s => s.ExpenseId == settlementId)
+            .Select(s => s.Amount)
+            .ToListAsync());
+
+        Assert.Equal(2, splits.Count);
+        Assert.Equal(0m, splits.Sum());
+        Assert.Equal(7m, splits.Max());
+    }
+
+    [Fact]
+    public async Task Editing_a_settlement_to_zero_or_a_negative_amount_is_rejected()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+
+        var zero = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 0m });
+        var negative = await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = -4m });
+
+        await ErrorResponseAssertions.AssertErrorAsync(zero, HttpStatusCode.BadRequest);
+        await ErrorResponseAssertions.AssertErrorAsync(negative, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Deleting_a_settlement_restores_the_debt_it_paid_down()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 10m);
+
+        var response = await group.Guest.DeleteSettlementAsync(group.Id, settlementId);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await factory.WaitForProcessedAsync();
+        Assert.Equal(-10m, (await group.Guest.ReadSummaryAsync(group.Id)).AmountOwedBy(group.GuestId, group.OwnerId));
+    }
+
+    /// <summary>
+    /// The counterparty can undo it too: every member can correct anyone's rows
+    /// (invariant 2).
+    /// </summary>
+    [Fact]
+    public async Task The_payee_can_delete_a_settlement_recorded_against_them()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 10m);
+
+        var response = await group.Owner.DeleteSettlementAsync(group.Id, settlementId);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_settlement_routes_refuse_an_ordinary_expense()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        await ErrorResponseAssertions.AssertErrorAsync(
+            await group.Owner.UpdateSettlementAsync(group.Id, expenseId, new { amount = 5m }),
+            HttpStatusCode.BadRequest);
+        await ErrorResponseAssertions.AssertErrorAsync(
+            await group.Owner.DeleteSettlementAsync(group.Id, expenseId),
+            HttpStatusCode.BadRequest);
+
+        Assert.NotNull(await factory.UseDbAsync(db => db.Expense.FirstOrDefaultAsync(e => e.Id == expenseId)));
+    }
+
+    [Fact]
+    public async Task A_non_member_can_neither_edit_nor_delete_a_settlement()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+        var user = await ApiClient.Create(factory).SignInAsync(name: "Stranger");
+        var stranger = ApiClient.Create(factory, user.Token);
+
+        Assert.Equal(
+            HttpStatusCode.Forbidden,
+            (await stranger.UpdateSettlementAsync(group.Id, settlementId, new { amount = 1m })).StatusCode);
+        Assert.Equal(
+            HttpStatusCode.Forbidden,
+            (await stranger.DeleteSettlementAsync(group.Id, settlementId)).StatusCode);
+    }
+
+    [Fact]
+    public async Task A_settlement_of_another_group_is_not_found()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+        var other = await GroupFixture.CreateAsync(factory);
+
+        var response = await other.Owner.DeleteSettlementAsync(other.Id, settlementId);
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task An_edit_can_move_the_settlement_date()
+    {
+        var (group, settlementId) = await SettledAsync(owed: 10m, settled: 4m);
+        var date = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        (await group.Guest.UpdateSettlementAsync(group.Id, settlementId, new { amount = 4m, date }))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal(date, await factory.UseDbAsync(db => db.Expense
+            .Where(e => e.Id == settlementId)
+            .Select(e => e.Date)
+            .FirstAsync()));
+    }
+}

--- a/Splitty-API/Splitty.API.Tests/TransactionDrainTests.cs
+++ b/Splitty-API/Splitty.API.Tests/TransactionDrainTests.cs
@@ -67,5 +67,11 @@ public sealed class TransactionDrainTests
 
         public Task SettleUp(int groupId, int userId, int peerId, decimal amount) =>
             throw new NotSupportedException();
+
+        public Task UpdateSettlement(int groupId, int expenseId, int userId, decimal amount, DateTime? date) =>
+            throw new NotSupportedException();
+
+        public Task DeleteSettlement(int groupId, int expenseId, int userId) =>
+            throw new NotSupportedException();
     }
 }

--- a/Splitty-API/Splitty.API/Controllers/GroupController.cs
+++ b/Splitty-API/Splitty.API/Controllers/GroupController.cs
@@ -175,6 +175,18 @@ public class GroupController(
         return Ok(expenses);
     }
 
+    [HttpGet("{groupId}/expenses/{expenseId:int}")]
+    public async Task<ActionResult<Expense>> GetExpenseById(int groupId, int expenseId)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (userId is null) return Unauthorized();
+
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
+        return Ok(await expenseService.FindByIdAsync(groupId, expenseId, int.Parse(userId)));
+    }
+
     [HttpPost("{groupId}/expenses")]
     public async Task<ActionResult<Expense>> CreateExpense(
         [FromBody] CreateExpenseRequest request,
@@ -198,6 +210,7 @@ public class GroupController(
             Description = request.Description,
             GroupId = groupId,
             PaidBy = request.PaidBy,
+            Date = request.Date,
             ExpenseSplits = request.Splits
         };
 
@@ -208,7 +221,7 @@ public class GroupController(
         return Ok(expense);
     }
 
-    [HttpPut("{groupId}/expenses/{expenseId}")]
+    [HttpPut("{groupId}/expenses/{expenseId:int}")]
     public async Task<ActionResult<Expense>> UpdateExpense(
         [FromBody] UpdateExpenseRequest request,
         int groupId,
@@ -234,6 +247,7 @@ public class GroupController(
             Amount = request.Amount,
             Description = request.Description,
             PaidBy = request.PaidBy,
+            Date = request.Date,
             ExpenseSplits = request.Splits
         };
 
@@ -244,6 +258,62 @@ public class GroupController(
         return Ok(expense);
     }
     
+    /// <summary>
+    /// Deleting removes splits, so the group's balances no longer follow from the rows that
+    /// remain. Skipping the recomputation would leave the deleted expense's money in the
+    /// balance table with nothing backing it — invariant 1.
+    /// </summary>
+    [HttpDelete("{groupId}/expenses/{expenseId:int}")]
+    public async Task<ActionResult> DeleteExpense(int groupId, int expenseId)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (userId is null) return Unauthorized();
+
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
+        await expenseService.DeleteAsync(groupId, expenseId, int.Parse(userId));
+
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
+
+        return NoContent();
+    }
+
+    [HttpPut("{groupId}/settlements/{expenseId:int}")]
+    public async Task<ActionResult> UpdateSettlement(
+        int groupId,
+        int expenseId,
+        [FromBody] UpdateSettlementRequest request)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (userId is null) return Unauthorized();
+
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
+        await balanceService.UpdateSettlement(groupId, expenseId, int.Parse(userId), request.Amount, request.Date);
+
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
+
+        return NoContent();
+    }
+
+    [HttpDelete("{groupId}/settlements/{expenseId:int}")]
+    public async Task<ActionResult> DeleteSettlement(int groupId, int expenseId)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (userId is null) return Unauthorized();
+
+        if (!await groupService.IsMemberAsync(groupId, int.Parse(userId))) return Forbid();
+
+        await balanceService.DeleteSettlement(groupId, expenseId, int.Parse(userId));
+
+        await balanceRecomputeQueue.EnqueueAsync(groupId);
+
+        return NoContent();
+    }
+
     /// <summary>
     /// Requests a recomputation rather than performing one. Replaying inline would race the
     /// worker replaying the same group, and both would insert the pairwise row neither found.

--- a/Splitty-API/Splitty.DTO/Internal/CreateExpenseDTO.cs
+++ b/Splitty-API/Splitty.DTO/Internal/CreateExpenseDTO.cs
@@ -8,6 +8,7 @@ public class CreateExpenseDTO
     public int PaidBy { get; set; }
     public Decimal Amount { get; set; }
     public string Description { get; set; }
+    public DateTime? Date { get; set; }
     public required List<ExpenseSplitDTO> ExpenseSplits { get; set; }
 }
 

--- a/Splitty-API/Splitty.DTO/Internal/UpdateExpenseDTO.cs
+++ b/Splitty-API/Splitty.DTO/Internal/UpdateExpenseDTO.cs
@@ -9,6 +9,7 @@ public class UpdateExpenseDTO
     public int? PaidBy { get; set; }
     public Decimal? Amount { get; set; }
     public string? Description { get; set; }
+    public DateTime? Date { get; set; }
     public List<UpdateExpenseSplitDTO>? ExpenseSplits { get; set; }
 }
 

--- a/Splitty-API/Splitty.DTO/Request/CreateExpenseRequest.cs
+++ b/Splitty-API/Splitty.DTO/Request/CreateExpenseRequest.cs
@@ -11,6 +11,12 @@ public class CreateExpenseRequest
     
     [Required(ErrorMessage = "Description is required")]
     public required string Description { get; set; }
+
+    /// <summary>
+    /// When the expense happened. Omitted means "now": the server falls back to the audit
+    /// timestamp rather than guessing. Future dates are allowed.
+    /// </summary>
+    public DateTime? Date { get; set; }
     
     /// <summary>
     /// Required rather than nullable so a payload omitting it is rejected by the JSON

--- a/Splitty-API/Splitty.DTO/Request/UpdateExpenseRequest.cs
+++ b/Splitty-API/Splitty.DTO/Request/UpdateExpenseRequest.cs
@@ -11,5 +11,7 @@ public class UpdateExpenseRequest
     
     public string? Description { get; set; }
     
+    public DateTime? Date { get; set; }
+    
     public List<UpdateExpenseSplitDTO>? Splits { get; set; }
 }

--- a/Splitty-API/Splitty.DTO/Request/UpdateSettlementRequest.cs
+++ b/Splitty-API/Splitty.DTO/Request/UpdateSettlementRequest.cs
@@ -1,0 +1,8 @@
+namespace Splitty.DTO.Request;
+
+public class UpdateSettlementRequest
+{
+    public Decimal Amount { get; set; }
+
+    public DateTime? Date { get; set; }
+}

--- a/Splitty-API/Splitty.Domain/Entities/Expense.cs
+++ b/Splitty-API/Splitty.Domain/Entities/Expense.cs
@@ -24,7 +24,15 @@ public class Expense
     public string Description { get; set; }
 
     public ExpenseType Type { get; set; } = ExpenseType.Expense;
-    
+
+    /// <summary>
+    /// When the expense happened, as the user says it did. Nullable because rows written
+    /// before the column existed have no user-supplied date; readers fall back to
+    /// <see cref="CreatedAt"/>. Future dates are allowed.
+    /// </summary>
+    public DateTime? Date { get; set; }
+
+    /// <summary>Audit timestamp, server-set, never client-supplied.</summary>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260821025045_Add_Expense_Date.Designer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260821025045_Add_Expense_Date.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Splitty.Infrastructure;
@@ -11,9 +12,11 @@ using Splitty.Infrastructure;
 namespace Splitty.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821025045_Add_Expense_Date")]
+    partial class Add_Expense_Date
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260821025045_Add_Expense_Date.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260821025045_Add_Expense_Date.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Splitty.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Expense_Date : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Date",
+                table: "Expense",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            // Backfilled so existing rows sort and group by the same instant they always
+            // showed. The column stays nullable: a row written before this migration has no
+            // user-supplied date, and readers fall back to CreatedAt anyway.
+            migrationBuilder.Sql(@"UPDATE ""Expense"" SET ""Date"" = ""CreatedAt"";");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Date",
+                table: "Expense");
+        }
+    }
+}

--- a/Splitty-API/Splitty.Repository/ExpenseRepository.cs
+++ b/Splitty-API/Splitty.Repository/ExpenseRepository.cs
@@ -40,6 +40,14 @@ public class ExpenseRepository(ApplicationDbContext context): IExpenseRepository
         return expense;
     }
     
+    public async Task DeleteAsync(Expense expense)
+    {
+        context.Expense.Remove(expense);
+        await context.SaveChangesAsync();
+    }
+
+    /// Newest first by the date the user gave, falling back to the audit timestamp for rows
+    /// written before the column existed. The client groups by the same expression.
     public async Task<List<Expense>> FindExpensesByGroupId(int groupId)
     {
         return await context.Expense
@@ -47,6 +55,8 @@ public class ExpenseRepository(ApplicationDbContext context): IExpenseRepository
             .ThenInclude(es => es.User)
             .Include(e => e.PaidByUser)
             .Where(e => e.GroupId == groupId)
+            .OrderByDescending(e => e.Date ?? e.CreatedAt)
+            .ThenByDescending(e => e.Id)
             .ToListAsync();
     }
 }

--- a/Splitty-API/Splitty.Repository/Interfaces/IExpenseRepository.cs
+++ b/Splitty-API/Splitty.Repository/Interfaces/IExpenseRepository.cs
@@ -8,5 +8,6 @@ public interface IExpenseRepository
     Task<List<Expense>> CreateExpenses(List<Expense> expenses);
     Task<Expense?> FindByIdAsync(int id);
     Task<Expense> UpdateAsync(Expense expense);
+    Task DeleteAsync(Expense expense);
     Task<List<Expense>> FindExpensesByGroupId(int groupId);
 }

--- a/Splitty-API/Splitty.Service/BalanceService.cs
+++ b/Splitty-API/Splitty.Service/BalanceService.cs
@@ -132,16 +132,112 @@ public class BalanceService(
     }
 
     /// <summary>
+    /// Edits an existing settlement, re-applying the cap of invariant 5 against the debt
+    /// the settlement itself does not account for. Splits are rebuilt from the new amount
+    /// rather than accepted, the same way <see cref="SettleUp"/> constructs them.
+    /// </summary>
+    public async Task UpdateSettlement(int groupId, int expenseId, int userId, decimal amount, DateTime? date)
+    {
+        if (amount <= 0)
+        {
+            throw new ArgumentException("Settlement amount must be greater than zero.");
+        }
+
+        await EnsureMemberAsync(groupId, userId);
+
+        var settlement = await FindSettlementAsync(groupId, expenseId);
+
+        var payerId = settlement.PaidBy;
+        var peerSplit = settlement.Splits.FirstOrDefault(s => s.UserId != payerId);
+
+        if (peerSplit is null)
+        {
+            throw new InvalidOperationException("This settlement has no counterparty.");
+        }
+
+        var payee = await userRepository.GetByIdAsync(peerSplit.UserId);
+
+        if (payee is null)
+        {
+            throw new KeyNotFoundException("User not found");
+        }
+
+        // The stored balance already counts this settlement, so the cap has to be read with
+        // that contribution removed — otherwise every edit is measured against a debt the
+        // row being edited has already paid down, and even a decrease is rejected. The
+        // contribution is read off the split, since that is what the replay sums.
+        var owed = await AmountOwedAsync(
+            groupId, payerId, peerSplit.UserId, excluding: Math.Abs(peerSplit.Amount));
+
+        if (amount > owed)
+        {
+            throw new ArgumentException(
+                $"Settlement amount exceeds the {owed} owed to {payee.Name}.");
+        }
+
+        settlement.Amount = amount;
+        settlement.Date = ExpenseDate.Normalize(date) ?? settlement.Date;
+        settlement.UpdatedAt = DateTime.UtcNow;
+
+        foreach (var split in settlement.Splits)
+        {
+            split.Amount = split.UserId == payerId ? amount : -amount;
+        }
+
+        ExpenseSplitInvariants.Ensure(
+            settlement.Type,
+            settlement.Amount,
+            settlement.Splits.Select(s => s.Amount));
+
+        await expenseRepository.UpdateAsync(settlement);
+    }
+
+    public async Task DeleteSettlement(int groupId, int expenseId, int userId)
+    {
+        await EnsureMemberAsync(groupId, userId);
+
+        await expenseRepository.DeleteAsync(await FindSettlementAsync(groupId, expenseId));
+    }
+
+    /// <summary>
+    /// A settlement is an <see cref="Expense"/> row, so this route can be handed an ordinary
+    /// expense id. Refusing it here keeps one mutation path per row type, per
+    /// docs/adr/0001-settlements-have-their-own-routes.md.
+    /// </summary>
+    private async Task<Expense> FindSettlementAsync(int groupId, int expenseId)
+    {
+        var expense = await expenseRepository.FindByIdAsync(expenseId);
+
+        if (expense is null || expense.GroupId != groupId)
+        {
+            throw new KeyNotFoundException("Settlement not found");
+        }
+
+        if (expense.Type != ExpenseType.Payment)
+        {
+            throw new InvalidOperationException(
+                "This is an expense, not a settlement. Use /group/{groupId}/expenses/{expenseId}.");
+        }
+
+        return expense;
+    }
+
+    /// <summary>
     /// What the caller may still settle with this peer, read from the stored pairwise row
     /// rather than recomputed. The replay credits the payer, so a negative amount on the
     /// caller's row is what the caller owes; anything else, including a group whose balances
     /// the worker has not written yet, leaves nothing to settle.
     /// </summary>
-    private async Task<decimal> AmountOwedAsync(int groupId, int userId, int peerId)
+    /// <param name="excluding">
+    /// A contribution already counted in the stored row that should not bound the caller —
+    /// the settlement being edited.
+    /// </param>
+    private async Task<decimal> AmountOwedAsync(int groupId, int userId, int peerId, decimal excluding = 0m)
     {
         var balance = await balanceRepository.GetPairwiseBalanceAsync(userId, peerId, groupId);
+        var amount = (balance?.Amount ?? 0m) - excluding;
 
-        return balance is { Amount: < 0 } ? -balance.Amount : 0;
+        return amount < 0 ? -amount : 0m;
     }
 
     private async Task EnsureMemberAsync(int groupId, int userId)

--- a/Splitty-API/Splitty.Service/ExpenseDate.cs
+++ b/Splitty-API/Splitty.Service/ExpenseDate.cs
@@ -1,0 +1,19 @@
+namespace Splitty.Service;
+
+/// <summary>
+/// The user-supplied expense date, forced to UTC before it reaches Npgsql, which rejects a
+/// non-UTC <see cref="DateTime"/> for a <c>timestamptz</c> column. A payload without an
+/// offset arrives as <see cref="DateTimeKind.Unspecified"/> and is read as already-UTC
+/// rather than as server-local time, so the stored instant does not depend on where the
+/// API happens to run.
+/// </summary>
+internal static class ExpenseDate
+{
+    public static DateTime? Normalize(DateTime? date) => date switch
+    {
+        null => null,
+        { Kind: DateTimeKind.Utc } => date,
+        { Kind: DateTimeKind.Unspecified } => DateTime.SpecifyKind(date.Value, DateTimeKind.Utc),
+        _ => date.Value.ToUniversalTime()
+    };
+}

--- a/Splitty-API/Splitty.Service/ExpenseService.cs
+++ b/Splitty-API/Splitty.Service/ExpenseService.cs
@@ -26,6 +26,7 @@ public class ExpenseService(
             Description = dto.Description,
             GroupId = dto.GroupId,
             PaidBy = dto.PaidBy,
+            Date = ExpenseDate.Normalize(dto.Date),
             Splits = splits.Select(s => new ExpenseSplit
             {
                 Amount = s.Amount,
@@ -41,6 +42,33 @@ public class ExpenseService(
     public async Task<Expense?> FindByIdAsync(int id)
     {
         return await expenseRepository.FindByIdAsync(id);
+    }
+
+    public async Task<Expense> FindByIdAsync(int groupId, int expenseId, int userId)
+    {
+        await EnsureMemberAsync(groupId, userId);
+
+        return await FindInGroupAsync(groupId, expenseId);
+    }
+
+    /// <summary>
+    /// Refuses settlements: they are deleted through their own route, which re-reads the
+    /// cap and keeps one delete path per row type. See
+    /// docs/adr/0001-settlements-have-their-own-routes.md.
+    /// </summary>
+    public async Task DeleteAsync(int groupId, int expenseId, int userId)
+    {
+        await EnsureMemberAsync(groupId, userId);
+
+        var expense = await FindInGroupAsync(groupId, expenseId);
+
+        if (expense.Type == ExpenseType.Payment)
+        {
+            throw new InvalidOperationException(
+                "This is a settlement. Delete it through /group/{groupId}/settlements/{expenseId}.");
+        }
+
+        await expenseRepository.DeleteAsync(expense);
     }
     
     public async Task<List<Expense>> FindExpensesByGroupId(int groupId, int userId)
@@ -68,6 +96,14 @@ public class ExpenseService(
 
         await EnsureMemberAsync(expense.GroupId, userId);
 
+        // Same reason the delete route refuses them: a settlement's amount is capped and its
+        // splits are rebuilt rather than accepted, neither of which this path does.
+        if (expense.Type == ExpenseType.Payment)
+        {
+            throw new InvalidOperationException(
+                "This is a settlement. Edit it through /group/{groupId}/settlements/{expenseId}.");
+        }
+
         // Validate the resulting state, not just the supplied fields: an
         // amount-only update must not leave a nonmember payer or split behind.
         await EnsureMemberAsync(expense.GroupId, dto.PaidBy ?? expense.PaidBy);
@@ -87,6 +123,8 @@ public class ExpenseService(
         expense.Amount = resultingAmount;
         expense.Description = dto.Description ?? expense.Description;
         expense.PaidBy = dto.PaidBy ?? expense.PaidBy;
+        expense.Date = ExpenseDate.Normalize(dto.Date) ?? expense.Date;
+        expense.UpdatedAt = DateTime.UtcNow;
         
         if (dto.ExpenseSplits is not null)
         {
@@ -99,6 +137,20 @@ public class ExpenseService(
         }
         
         await expenseRepository.UpdateAsync(expense);
+        return expense;
+    }
+
+    /// The expense must belong to the group the request was made against, otherwise a
+    /// member of group A could read or delete an expense of group B.
+    private async Task<Expense> FindInGroupAsync(int groupId, int expenseId)
+    {
+        var expense = await expenseRepository.FindByIdAsync(expenseId);
+
+        if (expense is null || expense.GroupId != groupId)
+        {
+            throw new KeyNotFoundException("Expense not found");
+        }
+
         return expense;
     }
 

--- a/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
+++ b/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
@@ -20,7 +20,7 @@ internal static class ExpenseSplitInvariants
                 EnsureExpense(amount, splits);
                 break;
             case ExpenseType.Payment:
-                EnsurePayment(splits);
+                EnsurePayment(amount, splits);
                 break;
         }
     }
@@ -49,21 +49,35 @@ internal static class ExpenseSplitInvariants
     }
 
     /// <summary>
-    /// A payment moves one amount between exactly two people, so its splits are equal in
-    /// magnitude and opposite in sign. Violating this means the settle path built the
-    /// expense wrong, which is why it throws rather than reporting a validation failure.
+    /// A payment moves one amount between exactly two people, so its splits are exactly
+    /// <c>[+Amount, -Amount]</c>. Checking them against <see cref="Expense.Amount"/> and not
+    /// only against each other is what stops an amount-only edit from changing the number
+    /// users read while moving no money: the balance replay reads the splits and never
+    /// reads <c>Amount</c>. Violating this means the settle path built the expense wrong,
+    /// which is why it throws rather than reporting a validation failure.
     /// </summary>
-    private static void EnsurePayment(List<decimal>? splits)
+    private static void EnsurePayment(decimal amount, List<decimal>? splits)
     {
         if (splits is null || splits.Count != 2)
         {
             throw new InvalidOperationException("A payment must have exactly two splits.");
         }
 
-        if (splits[0] != -splits[1] || splits[0] == 0)
+        if (amount <= 0)
+        {
+            throw new InvalidOperationException("A payment's amount must be greater than zero.");
+        }
+
+        if (splits[0] + splits[1] != 0)
         {
             throw new InvalidOperationException(
                 "A payment's splits must be equal in magnitude and opposite in sign.");
+        }
+
+        if (Math.Abs(splits[0]) != amount)
+        {
+            throw new InvalidOperationException(
+                "A payment's splits must match its amount.");
         }
     }
 }

--- a/Splitty-API/Splitty.Service/Interfaces/IBalanceService.cs
+++ b/Splitty-API/Splitty.Service/Interfaces/IBalanceService.cs
@@ -7,4 +7,6 @@ public interface IBalanceService
     Task<List<Balance>> CalculateGroupBalances(int groupId);
     Task<List<Balance>> GetGroupUserBalance(int groupId, int userId);
     Task SettleUp(int groupId, int userId, int peerId, decimal amount);
+    Task UpdateSettlement(int groupId, int expenseId, int userId, decimal amount, DateTime? date);
+    Task DeleteSettlement(int groupId, int expenseId, int userId);
 }

--- a/Splitty-API/Splitty.Service/Interfaces/IExpenseService.cs
+++ b/Splitty-API/Splitty.Service/Interfaces/IExpenseService.cs
@@ -7,6 +7,8 @@ public interface IExpenseService
 {
     Task<Expense> CreateAsync(CreateExpenseDTO dto, int userId);
     Task<Expense?> FindByIdAsync(int id);
+    Task<Expense> FindByIdAsync(int groupId, int expenseId, int userId);
+    Task DeleteAsync(int groupId, int expenseId, int userId);
     // Task<Expense> UpdateAsync(Expense expense); 
     Task<List<Expense>> FindExpensesByGroupId(int groupId, int userId);
     Task<Expense> UpdateAsync(UpdateExpenseDTO dto, int userId);

--- a/docs/adr/0001-settlements-have-their-own-routes.md
+++ b/docs/adr/0001-settlements-have-their-own-routes.md
@@ -1,0 +1,23 @@
+# Settlements are mutated through their own routes, not the expense routes
+
+A settlement is stored as an `Expense` with `Type = Payment`, so the obvious move is to let
+the expense `PUT`/`DELETE` routes handle both row types and branch on `Type`. We decided
+against it: settlements get `PUT`/`DELETE /group/{groupId}/settlements/{expenseId}`, and the
+expense `PUT` and `DELETE` routes refuse `Payment` rows outright.
+
+Sharing a route would mean the same request shape behaves under different rules depending on
+a field the client never sent — the settlement cap applies, splits are rebuilt from `Amount`
+rather than accepted, and `EnsurePayment` replaces `EnsureExpense`. Splitting the routes
+keeps one delete path per row type and keeps the cap somewhere a reader can find it.
+
+## Consequences
+
+- The expense `PUT` route refused nothing before this and would happily edit a settlement's
+  amount, which is a way around the cap. It refuses `Payment` rows now, for the same reason
+  the delete does.
+- The cap re-check on a settlement edit must exclude the settlement's own contribution to the
+  pairwise balance, or every edit fails against a balance that already counts it.
+- `ExpenseSplitInvariants.EnsurePayment` previously asserted only "two splits, opposite sign,
+  nonzero" and never that they matched `Amount`. Because the balance replay reads splits and
+  ignores `Expense.Amount`, an amount-only edit would have changed the displayed number and
+  moved no money. Tightened to assert `splits == [+Amount, -Amount]` as part of this work.


### PR DESCRIPTION
Closes #30.

## Routes

```
GET    /group/{groupId}/expenses/{expenseId}
DELETE /group/{groupId}/expenses/{expenseId}
PUT    /group/{groupId}/settlements/{expenseId}
DELETE /group/{groupId}/settlements/{expenseId}
```

All four check membership and return `Forbid()` for a non-member (invariant 3). Both deletes enqueue a balance recomputation — the surviving rows no longer imply the stored balances (invariant 1). An expense belonging to another group reads as `404` rather than `403`: the caller is a member of the group in the path, so it is a lookup failure.

## Settlements keep their own routes

Per `docs/adr/0001-settlements-have-their-own-routes.md` (included here). The settlement edit rebuilds both splits from the new `Amount` rather than accepting splits, and re-applies the settle cap with the settlement's **own** contribution excluded — the stored pairwise balance already counts the row being edited, so a raw cap read would reject even re-saving the amount already stored. There is a test for exactly that.

**Beyond the issue text:** the expense `PUT` route now refuses `Payment` rows as well, not only `DELETE`. It was a way around the cap — editing a settlement's amount through the expense route skipped it entirely. Flagging it since the issue only called for the delete.

## `EnsurePayment` bug

It asserted only "exactly two splits, equal magnitude, opposite sign, nonzero" and never checked them against `Expense.Amount`. The balance replay reads `Math.Abs(split.Amount)` and never reads `Expense.Amount`, so an amount-only edit of a payment changed the number users see and moved no money. Tightened to assert `splits == [+Amount, -Amount]`.

## Expense date

Nullable `Expense.Date`, client-supplied, accepted on create and update, future dates allowed. Migration backfills from `CreatedAt`; the column stays nullable because a pre-migration row has no user-supplied date. `CreatedAt` is untouched: server-set audit timestamp. Listing orders by `Date ?? CreatedAt`, newest first, tie-broken by id.

Dates are normalized to UTC before they reach Npgsql (`Splitty.Service/ExpenseDate.cs`); a payload without an offset is read as already-UTC rather than as server-local time, so the stored instant does not depend on where the API runs.

## Tests

27 new tests across `ExpenseReadAndDeleteTests`, `SettlementEditTests`, `ExpenseDateTests`. Full suite: 66 passed, 0 failed.

`CONTEXT.md` gained the expense-date and settlement-route entries.