### PR TITLE
ci: build API image to GHCR and deploy via Coolify

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,58 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Splitty-API/**'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Lowercase repository name
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      # The Dockerfile's COPY paths are relative to the solution directory, so the
+      # build context is Splitty-API rather than the repository root.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./Splitty-API
+          file: Splitty-API/Splitty.API/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ghcr.io/${{ steps.repo.outputs.name }}:latest
+            ghcr.io/${{ steps.repo.outputs.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Coolify
+        run: |
+          curl --fail-with-body --request GET '${{ secrets.COOLIFY_WEBHOOK }}' \
+            --header 'Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}'

--- a/Splitty-API/.dockerignore
+++ b/Splitty-API/.dockerignore
@@ -1,0 +1,13 @@
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.idea
+**/.vs
+**/.vscode
+**/*.user
+**/bin
+**/obj
+**/docker-compose*
+**/Dockerfile*
+**/node_modules

--- a/Splitty-API/Splitty.API/Program.cs
+++ b/Splitty-API/Splitty.API/Program.cs
@@ -179,6 +179,14 @@ builder.Services.AddSingleton<Channel<TransactionRequest>>(
 
 var app = builder.Build();
 
+// Apply pending migrations on boot so a deploy against a fresh or lagging database
+// self-heals; MigrateAsync is a no-op once the schema is current.
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await db.Database.MigrateAsync();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
Mirrors the CloudCertify pipeline: on push to `main` touching `Splitty-API/**`, build the API image, push to GHCR, then hit the Coolify deploy webhook.

## Changes

- **`.github/workflows/docker-publish.yml`** — build + push `ghcr.io/sn0wye/splitty:latest` and `:<sha>`, gha layer cache, then `GET` the Coolify webhook.
- **`Splitty-API/.dockerignore`** — the build context is `Splitty-API` (both here and in compose), so the root `.dockerignore` was never being read and `bin/`, `obj/`, `.env` were landing in the context.
- **`Program.cs`** — `MigrateAsync` after `builder.Build()`. Idempotent, and runs ahead of the `args.Contains("seed")` path so seeding gets a migrated schema.

Two deltas from CloudCertify's workflow: `setup-qemu-action`, needed to build arm64 on an amd64 runner, and `--fail-with-body` on the curl so a dead webhook fails the job instead of passing silently.

## Needs before this works

GitHub secrets: `COOLIFY_WEBHOOK`, `COOLIFY_TOKEN`.

Coolify env: `ConnectionStrings__DefaultConnection`, `Jwt__SecretKey`, `Google__ClientId`, `Google__ClientSecret`, `ASPNETCORE_ENVIRONMENT=Production`. Container listens on 8080 (Kestrel binds `0.0.0.0:8080` from appsettings).

## Notes

`platforms: linux/arm64` is copied from CloudCertify. If the Splitty host is x86 this needs to be `linux/amd64`.

Test suite is red on `main` already — all 66 fail at host build with `Configuration 'Jwt:SecretKey' is required.` Verified against baseline, unrelated to this branch, not fixed here.