### PR TITLE
feat(ios): expense create/edit drawer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -245,7 +245,27 @@ SwiftUI, `Views/` + `ViewModels/` + `Components/`, no third-party dependencies.
 - `TokenManager` — Keychain storage (`kSecClassGenericPassword`, service
   `com.splitty.app`).
 - `Services/*Service.swift` — thin wrappers over `APIClient`, async/await only. There are
-  no completion-handler variants; views call the async methods from `.task` / `Task`.
+  no completion-handler variants; views call the async methods from `.task` / `Task`. New
+  endpoints go in a service and call `APIClient.request` directly rather than adding another
+  pass-through method to the client.
+- `AuthenticationManager.currentUser` is the signed-in `User`: set from the sign-in response,
+  and fetched once on a cold launch that restored a Keychain token. Everything that says
+  "you" reads it. Not cached in UserDefaults — a second copy of the profile can go stale, a
+  Keychain token cannot. The profile route is `GET /auth`; there is no `/profile`.
+
+**Money is integer cents everywhere on the client**, converted to `Double` once at the
+request boundary (`Money`). The API validates that splits sum *exactly* to the total against
+a `decimal` column, so deriving them in floating point makes that a coin flip. The expense
+sheet is built from three pieces: `AmountExpression` (the amount field's state machine, with
+chained left-to-right arithmetic and no precedence), `SplitConfiguration` (payer plus an
+equal or custom mode, and the only place remainder cents are distributed — to the lowest user
+ids), and `ExpenseFormViewModel`, which holds the two together and decides when Save is
+available. A member who would land on zero is *omitted* from the payload, never sent as `0`.
+
+The amount field is a real `UITextField` whose `inputView` is the SwiftUI calculator pad
+(`AmountInputField`), not a `.decimalPad` with an accessory bar: a real responder is what
+gives the field a caret and makes moving focus to the description swap the pad for the system
+keyboard. The description field's `inputAccessoryView` carries the expense date picker.
 
 **The API base URL comes from the build configuration, not a literal.** The
 `SPLITTY_API_BASE_URL` build setting is substituted into the `SplittyAPIBaseURL` key of

--- a/Splitty/Splitty.xcodeproj/project.pbxproj
+++ b/Splitty/Splitty.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.snowye.Splitty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SPLITTY_API_BASE_URL = "http://localhost:8080";
+				SPLITTY_API_BASE_URL = "https://splitty.snowye.dev";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -468,7 +468,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.snowye.Splitty;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SPLITTY_API_BASE_URL = "";
+				SPLITTY_API_BASE_URL = "https://splitty.snowye.dev";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Splitty/Splitty/Components/AmountDisplay.swift
+++ b/Splitty/Splitty/Components/AmountDisplay.swift
@@ -19,19 +19,20 @@ struct AmountDisplay: View {
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Text(currencySymbol)
-                .font(.system(size: size * 0.7, weight: .semibold))
-                .baselineOffset(0)
-
             ForEach(glyphs, id: \.id) { glyph in
                 Text(glyph.character)
-                    .font(.system(size: size, weight: .semibold))
                     .transition(.asymmetric(
                         insertion: AnyTransition(BlurPushTransition(from: .below)),
                         removal: AnyTransition(BlurPushTransition(from: .above))
                     ))
             }
+
+            // Trailing, and the same size as the digits: the symbol is part of the number
+            // the way it is written, not a superscript hung off the front of it.
+            Text(currencySymbol)
+                .padding(.leading, size * 0.12)
         }
+        .font(.system(size: size, weight: .semibold))
         .monospacedDigit()
         .foregroundStyle(Color.primary)
         .lineLimit(1)

--- a/Splitty/Splitty/Components/AmountDisplay.swift
+++ b/Splitty/Splitty/Components/AmountDisplay.swift
@@ -1,0 +1,99 @@
+//
+//  AmountDisplay.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// The hero amount, drawn one glyph at a time so a digit can animate in on its own.
+///
+/// A `UITextField` renders its text as a single opaque run, so the field that owns the
+/// keypad stays invisible and this draws what it holds: each character is a separate view
+/// with a stable identity, which is what lets SwiftUI move the digits that stayed and
+/// transition only the one that changed.
+struct AmountDisplay: View {
+    let text: String
+    /// Currency is a static glyph — there is no currency field and no conversion.
+    var currencySymbol: String = "$"
+    var size: CGFloat = 76
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text(currencySymbol)
+                .font(.system(size: size * 0.7, weight: .semibold))
+                .baselineOffset(0)
+
+            ForEach(glyphs, id: \.id) { glyph in
+                Text(glyph.character)
+                    .font(.system(size: size, weight: .semibold))
+                    .transition(.asymmetric(
+                        insertion: AnyTransition(BlurPushTransition(from: .below)),
+                        removal: AnyTransition(BlurPushTransition(from: .above))
+                    ))
+            }
+        }
+        .monospacedDigit()
+        .foregroundStyle(Color.primary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.4)
+        .animation(.spring(response: 0.34, dampingFraction: 0.72), value: text)
+    }
+
+    /// Identity is position **and** character: appending leaves the earlier glyphs alone,
+    /// while replacing one retires the old glyph and introduces the new one in its place.
+    private var glyphs: [Glyph] {
+        text.enumerated().map { index, character in
+            Glyph(id: "\(index)-\(character)", character: String(character))
+        }
+    }
+
+    private struct Glyph {
+        let id: String
+        let character: String
+    }
+}
+
+/// A glyph arrives from below and leaves upward, blurring and shrinking at the far end of
+/// the travel — the motion blur a number picks up when it moves that fast.
+struct BlurPushTransition: Transition {
+    enum Origin {
+        case below
+        case above
+
+        var offset: CGFloat {
+            switch self {
+            case .below: return 0.45
+            case .above: return -0.45
+            }
+        }
+    }
+
+    let from: Origin
+
+    func body(content: Content, phase: TransitionPhase) -> some View {
+        content
+            .blur(radius: phase.isIdentity ? 0 : 9)
+            .scaleEffect(phase.isIdentity ? 1 : 0.55, anchor: .center)
+            .offset(y: phase.isIdentity ? 0 : from.offset * 90)
+            .opacity(phase.isIdentity ? 1 : 0)
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var text = "0"
+
+        var body: some View {
+            VStack(spacing: 40) {
+                AmountDisplay(text: text)
+                HStack {
+                    Button("2") { text = text == "0" ? "2" : text + "2" }
+                    Button("5") { text = text == "0" ? "5" : text + "5" }
+                    Button("⌫") { text = String(text.dropLast()); if text.isEmpty { text = "0" } }
+                }
+                .font(.title)
+            }
+        }
+    }
+    return Demo()
+}

--- a/Splitty/Splitty/Components/AmountDisplay.swift
+++ b/Splitty/Splitty/Components/AmountDisplay.swift
@@ -32,7 +32,7 @@ struct AmountDisplay: View {
             Text(currencySymbol)
                 .padding(.leading, size * 0.12)
         }
-        .font(.system(size: size, weight: .semibold))
+        .font(.system(size: size, weight: .semibold, design: .rounded))
         .monospacedDigit()
         .foregroundStyle(Color.expenseForeground)
         .lineLimit(1)

--- a/Splitty/Splitty/Components/AmountDisplay.swift
+++ b/Splitty/Splitty/Components/AmountDisplay.swift
@@ -34,7 +34,7 @@ struct AmountDisplay: View {
         }
         .font(.system(size: size, weight: .semibold))
         .monospacedDigit()
-        .foregroundStyle(Color.primary)
+        .foregroundStyle(Color.expenseForeground)
         .lineLimit(1)
         .minimumScaleFactor(0.4)
         .animation(.spring(response: 0.34, dampingFraction: 0.72), value: text)

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -64,7 +64,7 @@ struct ExpenseKeypad: View {
                         .font(.subheadline.weight(.medium))
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
-                        .background(Color.primary.opacity(0.07), in: Capsule())
+                        .background(Color.expenseForeground.opacity(0.07), in: Capsule())
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("keypad.paste")
@@ -112,12 +112,12 @@ private struct KeypadKeyStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.system(size: 32, weight: .regular))
-            .foregroundStyle(Color.primary)
+            .foregroundStyle(Color.expenseForeground)
             .frame(maxWidth: .infinity)
             .frame(height: 68)
             .background {
                 Circle()
-                    .fill(Color.primary.opacity(configuration.isPressed ? 0.07 : 0))
+                    .fill(Color.expenseForeground.opacity(configuration.isPressed ? 0.07 : 0))
                     .frame(width: 72, height: 72)
                     .scaleEffect(configuration.isPressed ? 1 : 0.6)
             }
@@ -137,9 +137,9 @@ struct ForwardButton: View {
         Button(action: action) {
             Image(systemName: "arrow.right")
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(Color(.systemBackground))
+                .foregroundStyle(Color.expenseBackground)
                 .frame(width: 52, height: 52)
-                .background(Color.primary.opacity(isEnabled ? 1 : 0.25), in: Circle())
+                .background(Color.expenseAccent.opacity(isEnabled ? 1 : 0.25), in: Circle())
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
@@ -177,7 +177,7 @@ struct AmountInputField: UIViewRepresentable {
         // A plain view, not `UIInputView`: the keyboard style paints its own material and
         // hairline, and the pad has to be indistinguishable from the sheet above it.
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.keypadHeight))
-        container.backgroundColor = .systemBackground
+        container.backgroundColor = ExpenseTheme.background
         container.autoresizingMask = .flexibleWidth
         hosting.view.frame = container.bounds
         hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -261,6 +261,7 @@ struct DescriptionInputField: UIViewRepresentable {
         let field = UITextField()
         field.delegate = context.coordinator
         field.font = .preferredFont(forTextStyle: .body)
+        field.textColor = ExpenseTheme.foreground
         field.placeholder = placeholder
         field.returnKeyType = .done
         field.autocapitalizationType = .sentences
@@ -272,7 +273,7 @@ struct DescriptionInputField: UIViewRepresentable {
         context.coordinator.hosting = hosting
 
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.accessoryHeight))
-        container.backgroundColor = .systemBackground
+        container.backgroundColor = ExpenseTheme.background
         container.autoresizingMask = .flexibleWidth
         hosting.view.frame = container.bounds
         hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -105,12 +105,13 @@ struct ExpenseKeypad: View {
     }
 }
 
-/// No key cap: a grey circle grows behind the glyph while the finger is down and fades out
-/// after it lifts, which is the whole of the key's chrome.
+/// No key cap: a grey circle fades in behind the glyph while the finger is down and fades
+/// out after it lifts, which is the whole of the key's chrome. It does not grow — the disc
+/// is always full size, so the only thing moving under the finger is opacity.
 private struct KeypadKeyStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 32, weight: .regular))
+            .font(.system(size: 32, weight: .medium, design: .rounded))
             .foregroundStyle(Color.expenseForeground)
             .frame(maxWidth: .infinity)
             .frame(height: 68)
@@ -118,7 +119,6 @@ private struct KeypadKeyStyle: ButtonStyle {
                 Circle()
                     .fill(Color.expenseForeground.opacity(configuration.isPressed ? 0.07 : 0))
                     .frame(width: 72, height: 72)
-                    .scaleEffect(configuration.isPressed ? 1 : 0.6)
             }
             .contentShape(Rectangle())
             .animation(.easeOut(duration: configuration.isPressed ? 0.08 : 0.2), value: configuration.isPressed)
@@ -130,7 +130,7 @@ private struct KeypadKeyStyle: ButtonStyle {
 /// black-on-white without a second asset.
 struct ForwardButton: View {
     let isEnabled: Bool
-    var diameter: CGFloat = 52
+    var diameter: CGFloat = 44
     let action: () -> Void
 
     var body: some View {

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -1,0 +1,372 @@
+//
+//  ExpenseKeypad.swift
+//  Splitty
+//
+
+import DataDetection
+import SwiftUI
+import UIKit
+
+/// Everything the pad can send back to the amount field.
+enum KeypadKey: Equatable {
+    case digit(Int)
+    case decimalPoint
+    case backspace
+    case clear
+    case operation(CalculatorOperator)
+    case equals
+    case pasteAmount(cents: Int)
+    case next
+}
+
+// MARK: - The pad
+
+/// The amount field's keyboard: a calculator row above a numeric pad, plus a clipboard
+/// price chip when there is one to offer.
+struct ExpenseKeypad: View {
+    let pendingOperator: CalculatorOperator?
+    let pasteableCents: Int?
+    let onKey: (KeypadKey) -> Void
+
+    private let digitRows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let pasteableCents {
+                Button {
+                    onKey(.pasteAmount(cents: pasteableCents))
+                } label: {
+                    Label("Paste \(Money.formatted(cents: pasteableCents))", systemImage: "doc.on.clipboard")
+                        .font(.subheadline.weight(.medium))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Color(.tertiarySystemFill), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("keypad.paste")
+            }
+
+            calculatorRow
+
+            HStack(spacing: 8) {
+                VStack(spacing: 8) {
+                    ForEach(digitRows, id: \.first) { row in
+                        HStack(spacing: 8) {
+                            ForEach(row, id: \.self) { digit in
+                                key("\(digit)") { onKey(.digit(digit)) }
+                            }
+                        }
+                    }
+                    HStack(spacing: 8) {
+                        key(".") { onKey(.decimalPoint) }
+                        key("0") { onKey(.digit(0)) }
+                        key(systemImage: "delete.left") { onKey(.backspace) }
+                    }
+                }
+
+                VStack(spacing: 8) {
+                    key("C", tint: .secondary) { onKey(.clear) }
+                    key("=", tint: .accentColor) { onKey(.equals) }
+                    Button {
+                        onKey(.next)
+                    } label: {
+                        Text("Next")
+                            .font(.body.weight(.semibold))
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundStyle(Color.white)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("keypad.next")
+                }
+                .frame(width: 88)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 16)
+    }
+
+    private var calculatorRow: some View {
+        HStack(spacing: 8) {
+            ForEach(CalculatorOperator.allCases, id: \.self) { operation in
+                Button {
+                    onKey(.operation(operation))
+                } label: {
+                    Text(operation.symbol)
+                        .font(.title3.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 36)
+                        .background(
+                            pendingOperator == operation ? Color.accentColor : Color(.tertiarySystemFill),
+                            in: RoundedRectangle(cornerRadius: 10)
+                        )
+                        .foregroundStyle(pendingOperator == operation ? Color.white : Color.primary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("keypad.operator.\(operation.symbol)")
+            }
+        }
+    }
+
+    private func key(_ title: String, tint: Color = .primary, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.title2)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+                .foregroundStyle(tint)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("keypad.key.\(title)")
+    }
+
+    private func key(systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+                .foregroundStyle(Color.primary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("keypad.key.\(systemImage)")
+    }
+}
+
+// MARK: - The amount field
+
+/// The amount field is a real `UITextField` whose `inputView` is the pad above.
+///
+/// Not a SwiftUI `TextField` with `.decimalPad` and an accessory bar: a real responder is
+/// what gives the field a caret and makes moving focus to the description swap the pad for
+/// the system keyboard, both without any code.
+struct AmountInputField: UIViewRepresentable {
+    let text: String
+    let pendingOperator: CalculatorOperator?
+    let pasteableCents: Int?
+    @Binding var isFocused: Bool
+    let onKey: (KeypadKey) -> Void
+
+    func makeUIView(context: Context) -> UITextField {
+        let field = UITextField()
+        field.delegate = context.coordinator
+        field.font = .systemFont(ofSize: 40, weight: .semibold)
+        field.textColor = .label
+        field.adjustsFontSizeToFitWidth = true
+        field.minimumFontSize = 22
+        field.accessibilityIdentifier = "expense.amount"
+
+        let hosting = UIHostingController(rootView: keypad(context: context))
+        hosting.view.backgroundColor = .clear
+        context.coordinator.hosting = hosting
+
+        let container = UIInputView(
+            frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.keypadHeight),
+            inputViewStyle: .keyboard
+        )
+        container.autoresizingMask = .flexibleWidth
+        hosting.view.frame = container.bounds
+        hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        container.addSubview(hosting.view)
+        field.inputView = container
+
+        return field
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.hosting?.rootView = keypad(context: context)
+
+        if uiView.text != text {
+            uiView.text = text
+        }
+
+        // Deferred: changing the first responder inside a SwiftUI update is a change the
+        // system may drop, and the handoff to the description is exactly that case.
+        if isFocused, !uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.becomeFirstResponder() }
+        } else if !isFocused, uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.resignFirstResponder() }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    private func keypad(context: Context) -> ExpenseKeypad {
+        ExpenseKeypad(
+            pendingOperator: pendingOperator,
+            pasteableCents: pasteableCents,
+            onKey: { key in context.coordinator.parent.onKey(key) }
+        )
+    }
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        static let keypadHeight: CGFloat = 300
+
+        var parent: AmountInputField
+        var hosting: UIHostingController<ExpenseKeypad>?
+
+        init(parent: AmountInputField) {
+            self.parent = parent
+        }
+
+        /// Every character arrives through the pad. Hardware keyboards and dictation would
+        /// otherwise write text the expression knows nothing about.
+        func textField(
+            _ textField: UITextField,
+            shouldChangeCharactersIn range: NSRange,
+            replacementString string: String
+        ) -> Bool {
+            false
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            let isFocused = parent.$isFocused
+            DispatchQueue.main.async { isFocused.wrappedValue = true }
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            let isFocused = parent.$isFocused
+            DispatchQueue.main.async { isFocused.wrappedValue = false }
+        }
+    }
+}
+
+// MARK: - The description field
+
+/// The description field, whose accessory bar carries the expense's date. A real date
+/// picker rather than a "Today/Yesterday" shortcut: the column accepts any date, including
+/// future ones.
+struct DescriptionInputField: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var date: Date
+    @Binding var isFocused: Bool
+    let placeholder: String
+
+    func makeUIView(context: Context) -> UITextField {
+        let field = UITextField()
+        field.delegate = context.coordinator
+        field.font = .preferredFont(forTextStyle: .body)
+        field.placeholder = placeholder
+        field.returnKeyType = .done
+        field.autocapitalizationType = .sentences
+        field.accessibilityIdentifier = "expense.description"
+        field.addTarget(context.coordinator, action: #selector(Coordinator.editingChanged(_:)), for: .editingChanged)
+
+        let hosting = UIHostingController(rootView: accessory(context: context))
+        hosting.view.backgroundColor = .clear
+        context.coordinator.hosting = hosting
+
+        let container = UIInputView(
+            frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.accessoryHeight),
+            inputViewStyle: .keyboard
+        )
+        container.autoresizingMask = .flexibleWidth
+        hosting.view.frame = container.bounds
+        hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        container.addSubview(hosting.view)
+        field.inputAccessoryView = container
+
+        return field
+    }
+
+    func updateUIView(_ uiView: UITextField, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.hosting?.rootView = accessory(context: context)
+
+        if uiView.text != text {
+            uiView.text = text
+        }
+
+        // Deferred: changing the first responder inside a SwiftUI update is a change the
+        // system may drop, and the handoff to the description is exactly that case.
+        if isFocused, !uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.becomeFirstResponder() }
+        } else if !isFocused, uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.resignFirstResponder() }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    private func accessory(context: Context) -> ExpenseDateAccessory {
+        ExpenseDateAccessory(
+            date: Binding(
+                get: { context.coordinator.parent.date },
+                set: { context.coordinator.parent.date = $0 }
+            ),
+            onDone: { context.coordinator.parent.isFocused = false }
+        )
+    }
+
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        static let accessoryHeight: CGFloat = 48
+
+        var parent: DescriptionInputField
+        var hosting: UIHostingController<ExpenseDateAccessory>?
+
+        init(parent: DescriptionInputField) {
+            self.parent = parent
+        }
+
+        @objc func editingChanged(_ textField: UITextField) {
+            parent.text = textField.text ?? ""
+        }
+
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+            return true
+        }
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            let isFocused = parent.$isFocused
+            DispatchQueue.main.async { isFocused.wrappedValue = true }
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            let isFocused = parent.$isFocused
+            DispatchQueue.main.async { isFocused.wrappedValue = false }
+        }
+    }
+}
+
+struct ExpenseDateAccessory: View {
+    @Binding var date: Date
+    let onDone: () -> Void
+
+    var body: some View {
+        HStack {
+            DatePicker("Date", selection: $date, displayedComponents: .date)
+                .labelsHidden()
+                .datePickerStyle(.compact)
+                .accessibilityIdentifier("expense.date")
+
+            Spacer()
+
+            Button("Done", action: onDone)
+                .font(.body.weight(.semibold))
+        }
+        .padding(.horizontal, 16)
+        .frame(maxHeight: .infinity)
+    }
+}
+
+// MARK: - Clipboard
+
+/// The price on the clipboard, if there is one.
+///
+/// The deployment target is 18.2, so there is no pre-detection fallback to write: either
+/// the system finds a money amount or the chip does not appear.
+enum ClipboardPrice {
+    static func detect() async -> Int? {
+        guard let match = try? await UIPasteboard.general
+            .detectedValues(for: [\.moneyAmounts])
+            .moneyAmounts
+            .first
+        else { return nil }
+
+        let cents = Money.cents(from: match.amount)
+        return cents > 0 ? cents : nil
+    }
+}

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -48,7 +48,6 @@ struct ExpenseKeypad: View {
                 key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
             }
         }
-        .padding(.horizontal, 12)
         .padding(.bottom, 8)
     }
 
@@ -131,14 +130,15 @@ private struct KeypadKeyStyle: ButtonStyle {
 /// black-on-white without a second asset.
 struct ForwardButton: View {
     let isEnabled: Bool
+    var diameter: CGFloat = 52
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             Image(systemName: "arrow.right")
-                .font(.system(size: 20, weight: .semibold))
+                .font(.system(size: diameter * 0.38, weight: .semibold))
                 .foregroundStyle(Color.expenseBackground)
-                .frame(width: 52, height: 52)
+                .frame(width: diameter, height: diameter)
                 .background(Color.expenseAccent.opacity(isEnabled ? 1 : 0.25), in: Circle())
         }
         .buttonStyle(.plain)
@@ -146,205 +146,9 @@ struct ForwardButton: View {
     }
 }
 
-// MARK: - The amount field
-
-/// The responder behind the amount: a real `UITextField` whose `inputView` is the pad
-/// above, kept invisible because `AmountDisplay` draws the number.
-///
-/// Not a SwiftUI `TextField` with `.decimalPad` and an accessory bar: a real responder is
-/// what makes moving focus to the description swap the pad for the system keyboard,
-/// without any code. It renders nothing itself — a text field draws its text as one opaque
-/// run, and the digits have to animate one at a time.
-struct AmountInputField: UIViewRepresentable {
-    let pasteableCents: Int?
-    let isNextEnabled: Bool
-    @Binding var isFocused: Bool
-    let onKey: (KeypadKey) -> Void
-
-    func makeUIView(context: Context) -> UITextField {
-        let field = UITextField()
-        field.delegate = context.coordinator
-        field.tintColor = .clear
-        field.textColor = .clear
-        field.backgroundColor = .clear
-        field.isAccessibilityElement = false
-        field.accessibilityIdentifier = "expense.amount"
-
-        let hosting = UIHostingController(rootView: keypad(context: context))
-        hosting.view.backgroundColor = .clear
-        context.coordinator.hosting = hosting
-
-        // A plain view, not `UIInputView`: the keyboard style paints its own material and
-        // hairline, and the pad has to be indistinguishable from the sheet above it.
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.keypadHeight))
-        container.backgroundColor = ExpenseTheme.background
-        container.autoresizingMask = .flexibleWidth
-        hosting.view.frame = container.bounds
-        hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        container.addSubview(hosting.view)
-        field.inputView = container
-
-        return field
-    }
-
-    func updateUIView(_ uiView: UITextField, context: Context) {
-        context.coordinator.parent = self
-        context.coordinator.hosting?.rootView = keypad(context: context)
-
-        // Deferred: changing the first responder inside a SwiftUI update is a change the
-        // system may drop, and the handoff to the description is exactly that case.
-        if isFocused, !uiView.isFirstResponder {
-            DispatchQueue.main.async { uiView.becomeFirstResponder() }
-        } else if !isFocused, uiView.isFirstResponder {
-            DispatchQueue.main.async { uiView.resignFirstResponder() }
-        }
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
-
-    private func keypad(context: Context) -> ExpenseKeypad {
-        ExpenseKeypad(
-            pasteableCents: pasteableCents,
-            isNextEnabled: isNextEnabled,
-            onKey: { key in context.coordinator.parent.onKey(key) }
-        )
-    }
-
-    final class Coordinator: NSObject, UITextFieldDelegate {
-        /// One action row and four digit rows, plus the padding around them.
-        static let keypadHeight: CGFloat = 356
-
-        var parent: AmountInputField
-        var hosting: UIHostingController<ExpenseKeypad>?
-
-        init(parent: AmountInputField) {
-            self.parent = parent
-        }
-
-        /// Every character arrives through the pad. Hardware keyboards and dictation would
-        /// otherwise write text the expression knows nothing about.
-        func textField(
-            _ textField: UITextField,
-            shouldChangeCharactersIn range: NSRange,
-            replacementString string: String
-        ) -> Bool {
-            false
-        }
-
-        func textFieldDidBeginEditing(_ textField: UITextField) {
-            let isFocused = parent.$isFocused
-            DispatchQueue.main.async { isFocused.wrappedValue = true }
-        }
-
-        func textFieldDidEndEditing(_ textField: UITextField) {
-            let isFocused = parent.$isFocused
-            DispatchQueue.main.async { isFocused.wrappedValue = false }
-        }
-    }
-}
-
-// MARK: - The description field
-
-/// The description field, whose accessory bar carries the expense's date and the same
-/// forward action the pad ends on. A real date picker rather than a "Today/Yesterday"
-/// shortcut: the column accepts any date, including future ones.
-struct DescriptionInputField: UIViewRepresentable {
-    @Binding var text: String
-    @Binding var date: Date
-    @Binding var isFocused: Bool
-    let placeholder: String
-    let isSubmitEnabled: Bool
-    let isSaving: Bool
-    let onSubmit: () -> Void
-
-    func makeUIView(context: Context) -> UITextField {
-        let field = UITextField()
-        field.delegate = context.coordinator
-        field.font = .preferredFont(forTextStyle: .body)
-        field.textColor = ExpenseTheme.foreground
-        field.placeholder = placeholder
-        field.returnKeyType = .done
-        field.autocapitalizationType = .sentences
-        field.accessibilityIdentifier = "expense.description"
-        field.addTarget(context.coordinator, action: #selector(Coordinator.editingChanged(_:)), for: .editingChanged)
-
-        let hosting = UIHostingController(rootView: accessory(context: context))
-        hosting.view.backgroundColor = .clear
-        context.coordinator.hosting = hosting
-
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.accessoryHeight))
-        container.backgroundColor = ExpenseTheme.background
-        container.autoresizingMask = .flexibleWidth
-        hosting.view.frame = container.bounds
-        hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        container.addSubview(hosting.view)
-        field.inputAccessoryView = container
-
-        return field
-    }
-
-    func updateUIView(_ uiView: UITextField, context: Context) {
-        context.coordinator.parent = self
-        context.coordinator.hosting?.rootView = accessory(context: context)
-
-        if uiView.text != text {
-            uiView.text = text
-        }
-
-        // Deferred: changing the first responder inside a SwiftUI update is a change the
-        // system may drop, and the handoff to the description is exactly that case.
-        if isFocused, !uiView.isFirstResponder {
-            DispatchQueue.main.async { uiView.becomeFirstResponder() }
-        } else if !isFocused, uiView.isFirstResponder {
-            DispatchQueue.main.async { uiView.resignFirstResponder() }
-        }
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
-
-    private func accessory(context: Context) -> ExpenseDateAccessory {
-        ExpenseDateAccessory(
-            date: Binding(
-                get: { context.coordinator.parent.date },
-                set: { context.coordinator.parent.date = $0 }
-            ),
-            isSubmitEnabled: isSubmitEnabled,
-            isSaving: isSaving,
-            onSubmit: { context.coordinator.parent.onSubmit() }
-        )
-    }
-
-    final class Coordinator: NSObject, UITextFieldDelegate {
-        static let accessoryHeight: CGFloat = 64
-
-        var parent: DescriptionInputField
-        var hosting: UIHostingController<ExpenseDateAccessory>?
-
-        init(parent: DescriptionInputField) {
-            self.parent = parent
-        }
-
-        @objc func editingChanged(_ textField: UITextField) {
-            parent.text = textField.text ?? ""
-        }
-
-        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            textField.resignFirstResponder()
-            return true
-        }
-
-        func textFieldDidBeginEditing(_ textField: UITextField) {
-            let isFocused = parent.$isFocused
-            DispatchQueue.main.async { isFocused.wrappedValue = true }
-        }
-
-        func textFieldDidEndEditing(_ textField: UITextField) {
-            let isFocused = parent.$isFocused
-            DispatchQueue.main.async { isFocused.wrappedValue = false }
-        }
-    }
-}
-
+/// The bar above the system keyboard while the description has focus: the expense's date,
+/// and the same forward arrow the pad ends on — which saves, since the description is the
+/// last thing the sheet asks for.
 struct ExpenseDateAccessory: View {
     @Binding var date: Date
     let isSubmitEnabled: Bool
@@ -352,25 +156,21 @@ struct ExpenseDateAccessory: View {
     let onSubmit: () -> Void
 
     var body: some View {
-        HStack {
-            DatePicker("Date", selection: $date, displayedComponents: .date)
-                .labelsHidden()
-                .datePickerStyle(.compact)
-                .accessibilityIdentifier("expense.date")
+        DatePicker("Date", selection: $date, displayedComponents: .date)
+            .labelsHidden()
+            .datePickerStyle(.compact)
+            .accessibilityIdentifier("expense.date")
 
-            Spacer()
+        Spacer()
 
-            if isSaving {
-                ProgressView()
-                    .frame(width: 52, height: 52)
-            } else {
-                ForwardButton(isEnabled: isSubmitEnabled, action: onSubmit)
-                    .accessibilityLabel("save")
-                    .accessibilityIdentifier("expense.save")
-            }
+        if isSaving {
+            ProgressView()
+                .frame(width: 36, height: 36)
+        } else {
+            ForwardButton(isEnabled: isSubmitEnabled, diameter: 36, action: onSubmit)
+                .accessibilityLabel("save")
+                .accessibilityIdentifier("expense.save")
         }
-        .padding(.horizontal, 16)
-        .frame(maxHeight: .infinity)
     }
 }
 

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -26,6 +26,10 @@ enum KeypadKey: Equatable {
 struct ExpenseKeypad: View {
     let pasteableCents: Int?
     let isNextEnabled: Bool
+    var isSaving: Bool = false
+    /// The digits hide while the system keyboard is up; the action row stays, so the
+    /// forward arrow keeps its place instead of moving to the other end of the sheet.
+    var showsDigits: Bool = true
     let onKey: (KeypadKey) -> Void
 
     private let digitRows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -34,18 +38,20 @@ struct ExpenseKeypad: View {
         VStack(spacing: 2) {
             actionRow
 
-            ForEach(digitRows, id: \.first) { row in
-                HStack(spacing: 0) {
-                    ForEach(row, id: \.self) { digit in
-                        key(title: "\(digit)") { onKey(.digit(digit)) }
+            if showsDigits {
+                ForEach(digitRows, id: \.first) { row in
+                    HStack(spacing: 0) {
+                        ForEach(row, id: \.self) { digit in
+                            key(title: "\(digit)") { onKey(.digit(digit)) }
+                        }
                     }
                 }
-            }
 
-            HStack(spacing: 0) {
-                key(title: ".") { onKey(.decimalPoint) }
-                key(title: "0") { onKey(.digit(0)) }
-                key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
+                HStack(spacing: 0) {
+                    key(title: ".") { onKey(.decimalPoint) }
+                    key(title: "0") { onKey(.digit(0)) }
+                    key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
+                }
             }
         }
         .padding(.bottom, 8)
@@ -71,13 +77,18 @@ struct ExpenseKeypad: View {
 
             Spacer(minLength: 0)
 
-            ForwardButton(isEnabled: isNextEnabled) { onKey(.next) }
-                .accessibilityLabel("next")
-                .accessibilityIdentifier("keypad.next")
-                .frame(width: 76)
+            if isSaving {
+                ProgressView()
+                    .frame(width: 44, height: 44)
+            } else {
+                ForwardButton(isEnabled: isNextEnabled) { onKey(.next) }
+                    .accessibilityLabel("next")
+                    .accessibilityIdentifier("keypad.next")
+            }
         }
         .frame(height: 60)
-        .padding(.horizontal, 8)
+        .padding(.leading, 8)
+        .padding(.trailing, 12)
     }
 
     private func key(
@@ -125,24 +136,39 @@ private struct KeypadKeyStyle: ButtonStyle {
     }
 }
 
-/// The sheet's primary action, and the only filled control on it: a solid disc in the
-/// foreground colour with the arrow punched out of it, so it reads white-on-black or
-/// black-on-white without a second asset.
+/// The sheet's primary action. Glass where the system has it, so it picks up the material
+/// and the press behaviour of every other prominent control on the OS; a flat disc in the
+/// accent colour before that.
 struct ForwardButton: View {
     let isEnabled: Bool
     var diameter: CGFloat = 44
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: "arrow.right")
-                .font(.system(size: diameter * 0.38, weight: .semibold))
-                .foregroundStyle(Color.expenseBackground)
-                .frame(width: diameter, height: diameter)
-                .background(Color.expenseAccent.opacity(isEnabled ? 1 : 0.25), in: Circle())
+        if #available(iOS 26.0, *) {
+            Button(action: action) {
+                glyph
+                    .frame(width: diameter, height: diameter)
+            }
+            .buttonStyle(.glassProminent)
+            .buttonBorderShape(.circle)
+            .tint(Color.expenseAccent)
+            .disabled(!isEnabled)
+        } else {
+            Button(action: action) {
+                glyph
+                    .frame(width: diameter, height: diameter)
+                    .background(Color.expenseAccent.opacity(isEnabled ? 1 : 0.25), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isEnabled)
         }
-        .buttonStyle(.plain)
-        .disabled(!isEnabled)
+    }
+
+    private var glyph: some View {
+        Image(systemName: "arrow.right")
+            .font(.system(size: diameter * 0.38, weight: .semibold))
+            .foregroundStyle(Color.expenseBackground)
     }
 }
 

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -3,7 +3,6 @@
 //  Splitty
 //
 
-import DataDetection
 import SwiftUI
 import UIKit
 
@@ -12,7 +11,6 @@ enum KeypadKey: Equatable {
     case digit(Int)
     case decimalPoint
     case backspace
-    case pasteAmount(cents: Int)
     case next
 }
 
@@ -24,7 +22,6 @@ enum KeypadKey: Equatable {
 /// Digits only. The arithmetic keys are gone: they turned a two-tap amount into a mode the
 /// user had to reason about, and the expression model still resolves whatever is typed.
 struct ExpenseKeypad: View {
-    let pasteableCents: Int?
     let isNextEnabled: Bool
     var isSaving: Bool = false
     /// The digits hide while the system keyboard is up; the action row stays, so the
@@ -57,24 +54,9 @@ struct ExpenseKeypad: View {
         .padding(.bottom, 8)
     }
 
-    /// The pad's only non-digit: the clipboard price on the left, and the forward action
-    /// sitting above the column it belongs to.
+    /// The pad's only non-digit: the forward action, over the column it belongs to.
     private var actionRow: some View {
         HStack(spacing: 12) {
-            if let pasteableCents {
-                Button {
-                    onKey(.pasteAmount(cents: pasteableCents))
-                } label: {
-                    Label("Paste \(Money.formatted(cents: pasteableCents))", systemImage: "doc.on.clipboard")
-                        .font(.subheadline.weight(.medium))
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(Color.expenseForeground.opacity(0.07), in: Capsule())
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("keypad.paste")
-            }
-
             Spacer(minLength: 0)
 
             if isSaving {
@@ -146,13 +128,17 @@ struct ForwardButton: View {
 
     var body: some View {
         if #available(iOS 26.0, *) {
+            // The material, not the button style: `.glassProminent` morphs and rescales the
+            // capsule under the finger, which on a 44pt disc reads as the button wobbling.
             Button(action: action) {
                 glyph
                     .frame(width: diameter, height: diameter)
+                    .glassEffect(
+                        .regular.tint(Color.expenseAccent.opacity(isEnabled ? 1 : 0.3)),
+                        in: .circle
+                    )
             }
-            .buttonStyle(.glassProminent)
-            .buttonBorderShape(.circle)
-            .tint(Color.expenseAccent)
+            .buttonStyle(.plain)
             .disabled(!isEnabled)
         } else {
             Button(action: action) {
@@ -196,24 +182,5 @@ struct ExpenseDatePicker: View {
         .presentationDetents([.height(460)])
         .presentationCornerRadius(28)
         .presentationBackground(Color.expenseBackground)
-    }
-}
-
-// MARK: - Clipboard
-
-/// The price on the clipboard, if there is one.
-///
-/// The deployment target is 18.2, so there is no pre-detection fallback to write: either
-/// the system finds a money amount or the chip does not appear.
-enum ClipboardPrice {
-    static func detect() async -> Int? {
-        guard let match = try? await UIPasteboard.general
-            .detectedValues(for: [\.moneyAmounts])
-            .moneyAmounts
-            .first
-        else { return nil }
-
-        let cents = Money.cents(from: match.amount)
-        return cents > 0 ? cents : nil
     }
 }

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -12,9 +12,6 @@ enum KeypadKey: Equatable {
     case digit(Int)
     case decimalPoint
     case backspace
-    case clear
-    case operation(CalculatorOperator)
-    case equals
     case pasteAmount(cents: Int)
     case next
 }
@@ -22,33 +19,20 @@ enum KeypadKey: Equatable {
 // MARK: - The pad
 
 /// The amount field's keyboard: borderless glyphs on the sheet's own background, with a
-/// circular press halo instead of a key cap. A calculator row sits above the digits,
-/// styled the same way so it reads as part of the pad rather than a toolbar bolted to it.
+/// circular press halo instead of a key cap.
+///
+/// Digits only. The arithmetic keys are gone: they turned a two-tap amount into a mode the
+/// user had to reason about, and the expression model still resolves whatever is typed.
 struct ExpenseKeypad: View {
-    let pendingOperator: CalculatorOperator?
     let pasteableCents: Int?
+    let isNextEnabled: Bool
     let onKey: (KeypadKey) -> Void
 
     private let digitRows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
     var body: some View {
-        VStack(spacing: 4) {
-            if let pasteableCents {
-                Button {
-                    onKey(.pasteAmount(cents: pasteableCents))
-                } label: {
-                    Label("Paste \(Money.formatted(cents: pasteableCents))", systemImage: "doc.on.clipboard")
-                        .font(.subheadline.weight(.medium))
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(Color(.tertiarySystemFill), in: Capsule())
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("keypad.paste")
-                .padding(.bottom, 4)
-            }
-
-            calculatorRow
+        VStack(spacing: 2) {
+            actionRow
 
             ForEach(digitRows, id: \.first) { row in
                 HStack(spacing: 0) {
@@ -65,36 +49,46 @@ struct ExpenseKeypad: View {
             }
         }
         .padding(.horizontal, 12)
-        .padding(.top, 6)
         .padding(.bottom, 8)
     }
 
-    /// The pending operator stays lit, so a half-typed expression is legible from the pad
-    /// itself rather than only from the amount.
-    private var calculatorRow: some View {
-        HStack(spacing: 0) {
-            ForEach(CalculatorOperator.allCases, id: \.self) { operation in
-                key(title: operation.symbol, isOn: pendingOperator == operation) {
-                    onKey(.operation(operation))
+    /// The pad's only non-digit: the clipboard price on the left, and the forward action
+    /// sitting above the column it belongs to.
+    private var actionRow: some View {
+        HStack(spacing: 12) {
+            if let pasteableCents {
+                Button {
+                    onKey(.pasteAmount(cents: pasteableCents))
+                } label: {
+                    Label("Paste \(Money.formatted(cents: pasteableCents))", systemImage: "doc.on.clipboard")
+                        .font(.subheadline.weight(.medium))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Color.primary.opacity(0.07), in: Capsule())
                 }
-                .accessibilityIdentifier("keypad.operator.\(operation.symbol)")
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("keypad.paste")
             }
-            key(title: "=") { onKey(.equals) }
-            key(systemImage: "arrow.forward", label: "next") { onKey(.next) }
+
+            Spacer(minLength: 0)
+
+            ForwardButton(isEnabled: isNextEnabled) { onKey(.next) }
+                .accessibilityLabel("next")
                 .accessibilityIdentifier("keypad.next")
+                .frame(width: 76)
         }
-        .font(.system(size: 24, weight: .regular))
+        .frame(height: 60)
+        .padding(.horizontal, 8)
     }
 
     private func key(
         title: String,
-        isOn: Bool = false,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             Text(title)
         }
-        .buttonStyle(KeypadKeyStyle(isOn: isOn))
+        .buttonStyle(KeypadKeyStyle())
         .accessibilityIdentifier("keypad.key.\(title)")
     }
 
@@ -106,7 +100,7 @@ struct ExpenseKeypad: View {
         Button(action: action) {
             Image(systemName: systemImage)
         }
-        .buttonStyle(KeypadKeyStyle(isOn: false))
+        .buttonStyle(KeypadKeyStyle())
         .accessibilityLabel(label)
         .accessibilityIdentifier("keypad.key.\(systemImage)")
     }
@@ -115,22 +109,40 @@ struct ExpenseKeypad: View {
 /// No key cap: a grey circle grows behind the glyph while the finger is down and fades out
 /// after it lifts, which is the whole of the key's chrome.
 private struct KeypadKeyStyle: ButtonStyle {
-    let isOn: Bool
-
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 34, weight: .regular))
+            .font(.system(size: 32, weight: .regular))
             .foregroundStyle(Color.primary)
             .frame(maxWidth: .infinity)
-            .frame(height: 64)
+            .frame(height: 68)
             .background {
                 Circle()
-                    .fill(Color.primary.opacity(configuration.isPressed || isOn ? 0.07 : 0))
+                    .fill(Color.primary.opacity(configuration.isPressed ? 0.07 : 0))
                     .frame(width: 72, height: 72)
-                    .scaleEffect(configuration.isPressed || isOn ? 1 : 0.6)
+                    .scaleEffect(configuration.isPressed ? 1 : 0.6)
             }
             .contentShape(Rectangle())
             .animation(.easeOut(duration: configuration.isPressed ? 0.08 : 0.2), value: configuration.isPressed)
+    }
+}
+
+/// The sheet's primary action, and the only filled control on it: a solid disc in the
+/// foreground colour with the arrow punched out of it, so it reads white-on-black or
+/// black-on-white without a second asset.
+struct ForwardButton: View {
+    let isEnabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "arrow.right")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color(.systemBackground))
+                .frame(width: 52, height: 52)
+                .background(Color.primary.opacity(isEnabled ? 1 : 0.25), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
     }
 }
 
@@ -144,8 +156,8 @@ private struct KeypadKeyStyle: ButtonStyle {
 /// without any code. It renders nothing itself — a text field draws its text as one opaque
 /// run, and the digits have to animate one at a time.
 struct AmountInputField: UIViewRepresentable {
-    let pendingOperator: CalculatorOperator?
     let pasteableCents: Int?
+    let isNextEnabled: Bool
     @Binding var isFocused: Bool
     let onKey: (KeypadKey) -> Void
 
@@ -162,10 +174,10 @@ struct AmountInputField: UIViewRepresentable {
         hosting.view.backgroundColor = .clear
         context.coordinator.hosting = hosting
 
-        let container = UIInputView(
-            frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.keypadHeight),
-            inputViewStyle: .keyboard
-        )
+        // A plain view, not `UIInputView`: the keyboard style paints its own material and
+        // hairline, and the pad has to be indistinguishable from the sheet above it.
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.keypadHeight))
+        container.backgroundColor = .systemBackground
         container.autoresizingMask = .flexibleWidth
         hosting.view.frame = container.bounds
         hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -192,15 +204,15 @@ struct AmountInputField: UIViewRepresentable {
 
     private func keypad(context: Context) -> ExpenseKeypad {
         ExpenseKeypad(
-            pendingOperator: pendingOperator,
             pasteableCents: pasteableCents,
+            isNextEnabled: isNextEnabled,
             onKey: { key in context.coordinator.parent.onKey(key) }
         )
     }
 
     final class Coordinator: NSObject, UITextFieldDelegate {
-        /// Five borderless rows, each 64pt, plus the padding around them.
-        static let keypadHeight: CGFloat = 360
+        /// One action row and four digit rows, plus the padding around them.
+        static let keypadHeight: CGFloat = 356
 
         var parent: AmountInputField
         var hosting: UIHostingController<ExpenseKeypad>?
@@ -233,14 +245,17 @@ struct AmountInputField: UIViewRepresentable {
 
 // MARK: - The description field
 
-/// The description field, whose accessory bar carries the expense's date. A real date
-/// picker rather than a "Today/Yesterday" shortcut: the column accepts any date, including
-/// future ones.
+/// The description field, whose accessory bar carries the expense's date and the same
+/// forward action the pad ends on. A real date picker rather than a "Today/Yesterday"
+/// shortcut: the column accepts any date, including future ones.
 struct DescriptionInputField: UIViewRepresentable {
     @Binding var text: String
     @Binding var date: Date
     @Binding var isFocused: Bool
     let placeholder: String
+    let isSubmitEnabled: Bool
+    let isSaving: Bool
+    let onSubmit: () -> Void
 
     func makeUIView(context: Context) -> UITextField {
         let field = UITextField()
@@ -256,10 +271,8 @@ struct DescriptionInputField: UIViewRepresentable {
         hosting.view.backgroundColor = .clear
         context.coordinator.hosting = hosting
 
-        let container = UIInputView(
-            frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.accessoryHeight),
-            inputViewStyle: .keyboard
-        )
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: Coordinator.accessoryHeight))
+        container.backgroundColor = .systemBackground
         container.autoresizingMask = .flexibleWidth
         hosting.view.frame = container.bounds
         hosting.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -294,12 +307,14 @@ struct DescriptionInputField: UIViewRepresentable {
                 get: { context.coordinator.parent.date },
                 set: { context.coordinator.parent.date = $0 }
             ),
-            onDone: { context.coordinator.parent.isFocused = false }
+            isSubmitEnabled: isSubmitEnabled,
+            isSaving: isSaving,
+            onSubmit: { context.coordinator.parent.onSubmit() }
         )
     }
 
     final class Coordinator: NSObject, UITextFieldDelegate {
-        static let accessoryHeight: CGFloat = 48
+        static let accessoryHeight: CGFloat = 64
 
         var parent: DescriptionInputField
         var hosting: UIHostingController<ExpenseDateAccessory>?
@@ -331,7 +346,9 @@ struct DescriptionInputField: UIViewRepresentable {
 
 struct ExpenseDateAccessory: View {
     @Binding var date: Date
-    let onDone: () -> Void
+    let isSubmitEnabled: Bool
+    let isSaving: Bool
+    let onSubmit: () -> Void
 
     var body: some View {
         HStack {
@@ -342,8 +359,14 @@ struct ExpenseDateAccessory: View {
 
             Spacer()
 
-            Button("Done", action: onDone)
-                .font(.body.weight(.semibold))
+            if isSaving {
+                ProgressView()
+                    .frame(width: 52, height: 52)
+            } else {
+                ForwardButton(isEnabled: isSubmitEnabled, action: onSubmit)
+                    .accessibilityLabel("save")
+                    .accessibilityIdentifier("expense.save")
+            }
         }
         .padding(.horizontal, 16)
         .frame(maxHeight: .infinity)

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -25,7 +25,9 @@ struct ExpenseKeypad: View {
     let isNextEnabled: Bool
     var isSaving: Bool = false
     /// The digits hide while the system keyboard is up; the action row stays, so the
-    /// forward arrow keeps its place instead of moving to the other end of the sheet.
+    /// forward arrow keeps its place instead of moving to the other end of the sheet. The
+    /// grid keeps its space either way — collapsing it moved the arrow down at the same
+    /// moment the keyboard moved it up.
     var showsDigits: Bool = true
     let onKey: (KeypadKey) -> Void
 
@@ -35,7 +37,7 @@ struct ExpenseKeypad: View {
         VStack(spacing: 2) {
             actionRow
 
-            if showsDigits {
+            VStack(spacing: 2) {
                 ForEach(digitRows, id: \.first) { row in
                     HStack(spacing: 0) {
                         ForEach(row, id: \.self) { digit in
@@ -50,6 +52,8 @@ struct ExpenseKeypad: View {
                     key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
                 }
             }
+            .opacity(showsDigits ? 1 : 0)
+            .allowsHitTesting(showsDigits)
         }
         .padding(.bottom, 8)
     }

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -21,8 +21,9 @@ enum KeypadKey: Equatable {
 
 // MARK: - The pad
 
-/// The amount field's keyboard: a calculator row above a numeric pad, plus a clipboard
-/// price chip when there is one to offer.
+/// The amount field's keyboard: borderless glyphs on the sheet's own background, with a
+/// circular press halo instead of a key cap. A calculator row sits above the digits,
+/// styled the same way so it reads as part of the pad rather than a toolbar bolted to it.
 struct ExpenseKeypad: View {
     let pendingOperator: CalculatorOperator?
     let pasteableCents: Int?
@@ -31,7 +32,7 @@ struct ExpenseKeypad: View {
     private let digitRows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 4) {
             if let pasteableCents {
                 Button {
                     onKey(.pasteAmount(cents: pasteableCents))
@@ -44,105 +45,105 @@ struct ExpenseKeypad: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("keypad.paste")
+                .padding(.bottom, 4)
             }
 
             calculatorRow
 
-            HStack(spacing: 8) {
-                VStack(spacing: 8) {
-                    ForEach(digitRows, id: \.first) { row in
-                        HStack(spacing: 8) {
-                            ForEach(row, id: \.self) { digit in
-                                key("\(digit)") { onKey(.digit(digit)) }
-                            }
-                        }
-                    }
-                    HStack(spacing: 8) {
-                        key(".") { onKey(.decimalPoint) }
-                        key("0") { onKey(.digit(0)) }
-                        key(systemImage: "delete.left") { onKey(.backspace) }
+            ForEach(digitRows, id: \.first) { row in
+                HStack(spacing: 0) {
+                    ForEach(row, id: \.self) { digit in
+                        key(title: "\(digit)") { onKey(.digit(digit)) }
                     }
                 }
+            }
 
-                VStack(spacing: 8) {
-                    key("C", tint: .secondary) { onKey(.clear) }
-                    key("=", tint: .accentColor) { onKey(.equals) }
-                    Button {
-                        onKey(.next)
-                    } label: {
-                        Text("Next")
-                            .font(.body.weight(.semibold))
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 10))
-                            .foregroundStyle(Color.white)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("keypad.next")
-                }
-                .frame(width: 88)
+            HStack(spacing: 0) {
+                key(title: ".") { onKey(.decimalPoint) }
+                key(title: "0") { onKey(.digit(0)) }
+                key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
             }
         }
         .padding(.horizontal, 12)
-        .padding(.top, 10)
-        .padding(.bottom, 16)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
     }
 
+    /// The pending operator stays lit, so a half-typed expression is legible from the pad
+    /// itself rather than only from the amount.
     private var calculatorRow: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 0) {
             ForEach(CalculatorOperator.allCases, id: \.self) { operation in
-                Button {
+                key(title: operation.symbol, isOn: pendingOperator == operation) {
                     onKey(.operation(operation))
-                } label: {
-                    Text(operation.symbol)
-                        .font(.title3.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 36)
-                        .background(
-                            pendingOperator == operation ? Color.accentColor : Color(.tertiarySystemFill),
-                            in: RoundedRectangle(cornerRadius: 10)
-                        )
-                        .foregroundStyle(pendingOperator == operation ? Color.white : Color.primary)
                 }
-                .buttonStyle(.plain)
                 .accessibilityIdentifier("keypad.operator.\(operation.symbol)")
             }
+            key(title: "=") { onKey(.equals) }
+            key(systemImage: "arrow.forward", label: "next") { onKey(.next) }
+                .accessibilityIdentifier("keypad.next")
         }
+        .font(.system(size: 24, weight: .regular))
     }
 
-    private func key(_ title: String, tint: Color = .primary, action: @escaping () -> Void) -> some View {
+    private func key(
+        title: String,
+        isOn: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.title2)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
-                .foregroundStyle(tint)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(KeypadKeyStyle(isOn: isOn))
         .accessibilityIdentifier("keypad.key.\(title)")
     }
 
-    private func key(systemImage: String, action: @escaping () -> Void) -> some View {
+    private func key(
+        systemImage: String,
+        label: String,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             Image(systemName: systemImage)
-                .font(.title3)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
-                .foregroundStyle(Color.primary)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(KeypadKeyStyle(isOn: false))
+        .accessibilityLabel(label)
         .accessibilityIdentifier("keypad.key.\(systemImage)")
+    }
+}
+
+/// No key cap: a grey circle grows behind the glyph while the finger is down and fades out
+/// after it lifts, which is the whole of the key's chrome.
+private struct KeypadKeyStyle: ButtonStyle {
+    let isOn: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 34, weight: .regular))
+            .foregroundStyle(Color.primary)
+            .frame(maxWidth: .infinity)
+            .frame(height: 64)
+            .background {
+                Circle()
+                    .fill(Color.primary.opacity(configuration.isPressed || isOn ? 0.07 : 0))
+                    .frame(width: 72, height: 72)
+                    .scaleEffect(configuration.isPressed || isOn ? 1 : 0.6)
+            }
+            .contentShape(Rectangle())
+            .animation(.easeOut(duration: configuration.isPressed ? 0.08 : 0.2), value: configuration.isPressed)
     }
 }
 
 // MARK: - The amount field
 
-/// The amount field is a real `UITextField` whose `inputView` is the pad above.
+/// The responder behind the amount: a real `UITextField` whose `inputView` is the pad
+/// above, kept invisible because `AmountDisplay` draws the number.
 ///
 /// Not a SwiftUI `TextField` with `.decimalPad` and an accessory bar: a real responder is
-/// what gives the field a caret and makes moving focus to the description swap the pad for
-/// the system keyboard, both without any code.
+/// what makes moving focus to the description swap the pad for the system keyboard,
+/// without any code. It renders nothing itself — a text field draws its text as one opaque
+/// run, and the digits have to animate one at a time.
 struct AmountInputField: UIViewRepresentable {
-    let text: String
     let pendingOperator: CalculatorOperator?
     let pasteableCents: Int?
     @Binding var isFocused: Bool
@@ -151,10 +152,10 @@ struct AmountInputField: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextField {
         let field = UITextField()
         field.delegate = context.coordinator
-        field.font = .systemFont(ofSize: 40, weight: .semibold)
-        field.textColor = .label
-        field.adjustsFontSizeToFitWidth = true
-        field.minimumFontSize = 22
+        field.tintColor = .clear
+        field.textColor = .clear
+        field.backgroundColor = .clear
+        field.isAccessibilityElement = false
         field.accessibilityIdentifier = "expense.amount"
 
         let hosting = UIHostingController(rootView: keypad(context: context))
@@ -178,10 +179,6 @@ struct AmountInputField: UIViewRepresentable {
         context.coordinator.parent = self
         context.coordinator.hosting?.rootView = keypad(context: context)
 
-        if uiView.text != text {
-            uiView.text = text
-        }
-
         // Deferred: changing the first responder inside a SwiftUI update is a change the
         // system may drop, and the handoff to the description is exactly that case.
         if isFocused, !uiView.isFirstResponder {
@@ -202,7 +199,8 @@ struct AmountInputField: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextFieldDelegate {
-        static let keypadHeight: CGFloat = 300
+        /// Five borderless rows, each 64pt, plus the padding around them.
+        static let keypadHeight: CGFloat = 360
 
         var parent: AmountInputField
         var hosting: UIHostingController<ExpenseKeypad>?

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -146,31 +146,30 @@ struct ForwardButton: View {
     }
 }
 
-/// The bar above the system keyboard while the description has focus: the expense's date,
-/// and the same forward arrow the pad ends on — which saves, since the description is the
-/// last thing the sheet asks for.
-struct ExpenseDateAccessory: View {
+/// The date, presented rather than parked in an accessory bar: a bar above the keyboard
+/// came with a border the sheet does not otherwise have and sat flush against the keys.
+/// Full size and from the bottom, it is the same gesture as everything else here.
+struct ExpenseDatePicker: View {
     @Binding var date: Date
-    let isSubmitEnabled: Bool
-    let isSaving: Bool
-    let onSubmit: () -> Void
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        DatePicker("Date", selection: $date, displayedComponents: .date)
-            .labelsHidden()
-            .datePickerStyle(.compact)
-            .accessibilityIdentifier("expense.date")
+        VStack(spacing: 16) {
+            DatePicker("Date", selection: $date, displayedComponents: .date)
+                .labelsHidden()
+                .datePickerStyle(.graphical)
+                .tint(Color.expenseAccent)
+                .accessibilityIdentifier("expense.datePicker")
 
-        Spacer()
-
-        if isSaving {
-            ProgressView()
-                .frame(width: 36, height: 36)
-        } else {
-            ForwardButton(isEnabled: isSubmitEnabled, diameter: 36, action: onSubmit)
-                .accessibilityLabel("save")
-                .accessibilityIdentifier("expense.save")
+            ForwardButton(isEnabled: true, diameter: 44) { dismiss() }
+                .accessibilityLabel("done")
         }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.expenseBackground)
+        .presentationDetents([.height(460)])
+        .presentationCornerRadius(28)
+        .presentationBackground(Color.expenseBackground)
     }
 }
 

--- a/Splitty/Splitty/Components/ExpenseTheme.swift
+++ b/Splitty/Splitty/Components/ExpenseTheme.swift
@@ -1,0 +1,47 @@
+//
+//  ExpenseTheme.swift
+//  Splitty
+//
+
+import SwiftUI
+import UIKit
+
+/// The expense sheet's palette, pinned to exact values rather than to the system's
+/// semantic colours.
+///
+/// `systemBackground` is pure black in dark mode, which is not the surface this sheet is
+/// meant to be, and the pad is hosted in UIKit — both sides need the same colour from one
+/// definition or the seam comes back.
+enum ExpenseTheme {
+    /// The sheet's surface, and the pad's.
+    static let background = dynamic(dark: 0x1C1C1E, light: 0xFEFEFE)
+
+    /// The amount and the keys.
+    static let foreground = dynamic(dark: 0xFEFEFE, light: 0x000000)
+
+    /// The one filled control: the forward arrow's disc. Its glyph is `background`.
+    static let accent = dynamic(dark: 0xF3F3F4, light: 0x191919)
+
+    private static func dynamic(dark: Int, light: Int) -> UIColor {
+        UIColor { traits in
+            traits.userInterfaceStyle == .dark ? UIColor(hex: dark) : UIColor(hex: light)
+        }
+    }
+}
+
+extension Color {
+    static let expenseBackground = Color(ExpenseTheme.background)
+    static let expenseForeground = Color(ExpenseTheme.foreground)
+    static let expenseAccent = Color(ExpenseTheme.accent)
+}
+
+private extension UIColor {
+    convenience init(hex: Int) {
+        self.init(
+            red: CGFloat((hex >> 16) & 0xFF) / 255,
+            green: CGFloat((hex >> 8) & 0xFF) / 255,
+            blue: CGFloat(hex & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}

--- a/Splitty/Splitty/Components/SwipeToDeleteRow.swift
+++ b/Splitty/Splitty/Components/SwipeToDeleteRow.swift
@@ -39,8 +39,11 @@ struct SwipeToDeleteRow<Content: View>: View {
                 .offset(x: shownOffset)
         }
         .animation(.snappy(duration: 0.25), value: offset)
-        .gesture(
-            DragGesture(minimumDistance: 12)
+        // Simultaneous, not exclusive: a plain `.gesture` loses the drag to the list's own
+        // pan recogniser, which is why the row stopped swiping at all. Both see the drag,
+        // and the horizontal-dominance check below is what keeps a scroll a scroll.
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 18)
                 .updating($translation) { value, state, _ in
                     // Vertical intent belongs to the list, so only the horizontal part of a
                     // drag that is mostly horizontal is taken.

--- a/Splitty/Splitty/Components/SwipeToDeleteRow.swift
+++ b/Splitty/Splitty/Components/SwipeToDeleteRow.swift
@@ -18,26 +18,32 @@ struct SwipeToDeleteRow<Content: View>: View {
     @GestureState private var translation: CGFloat = 0
 
     private static var actionWidth: CGFloat { 88 }
-    /// Past this the row commits on release, the way a full swipe does in a system list.
-    private static var commitWidth: CGFloat { 260 }
+    /// Past this, releasing asks. Short of it the row snaps back and nothing happens.
+    private static var commitWidth: CGFloat { 44 }
 
     var body: some View {
         ZStack(alignment: .trailing) {
+            // Tied to the card's edge rather than parked at the row's: the button arrives
+            // with the drag the way a system swipe action does, and stretches to fill
+            // anything dragged past its width.
             Button(action: delete) {
                 Image(systemName: "trash")
                     .font(.system(size: 20))
                     .foregroundStyle(.white)
                     .frame(width: Self.actionWidth)
-                    .frame(maxHeight: .infinity)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                     .background(Color.red)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Delete")
+            .frame(width: max(Self.actionWidth, -shownOffset))
+            .offset(x: max(0, Self.actionWidth + shownOffset))
 
             content
                 .background(Color("card"))
                 .offset(x: shownOffset)
         }
+        .clipped()
         .animation(.snappy(duration: 0.25), value: offset)
         // Simultaneous, not exclusive: a plain `.gesture` loses the drag to the list's own
         // pan recogniser, which is why the row stopped swiping at all. Both see the drag,
@@ -66,16 +72,16 @@ struct SwipeToDeleteRow<Content: View>: View {
             : raw
     }
 
+    /// The row does not stay open. Releasing past the threshold asks the question and
+    /// closes; the drag is the gesture, and the alert is where the decision is made.
     private func settle(_ value: DragGesture.Value) {
         guard abs(value.translation.width) > abs(value.translation.height) else { return }
 
         let travelled = offset + value.translation.width
+        offset = 0
 
         if travelled < -Self.commitWidth {
-            offset = 0
             onDelete()
-        } else {
-            offset = travelled < -Self.actionWidth / 2 ? -Self.actionWidth : 0
         }
     }
 

--- a/Splitty/Splitty/Components/SwipeToDeleteRow.swift
+++ b/Splitty/Splitty/Components/SwipeToDeleteRow.swift
@@ -11,10 +11,12 @@ import SwiftUI
 /// rows are square and edge to edge. The gesture is the same one — drag to reveal, tap to
 /// act, full swipe to act directly — so what changes is the shape, not the behaviour.
 struct SwipeToDeleteRow<Content: View>: View {
+    let onTap: () -> Void
     let onDelete: () -> Void
     @ViewBuilder var content: Content
 
     @State private var offset: CGFloat = 0
+    @State private var isSwiping = false
     @GestureState private var translation: CGFloat = 0
 
     private static var actionWidth: CGFloat { 88 }
@@ -39,8 +41,16 @@ struct SwipeToDeleteRow<Content: View>: View {
             .frame(width: max(Self.actionWidth, -shownOffset))
             .offset(x: max(0, Self.actionWidth + shownOffset))
 
+            // A tap gesture the swipe can veto, rather than a `Button`: the row is the
+            // button's whole area, so a finger that swipes never leaves it, and releasing
+            // counted as a tap and opened the expense.
             content
                 .background(Color("card"))
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    guard !isSwiping else { return }
+                    onTap()
+                }
                 .offset(x: shownOffset)
         }
         .clipped()
@@ -58,7 +68,19 @@ struct SwipeToDeleteRow<Content: View>: View {
                     }
                     state = value.translation.width
                 }
-                .onEnded(settle)
+                .onChanged { value in
+                    if abs(value.translation.width) > abs(value.translation.height) {
+                        isSwiping = true
+                    }
+                }
+                .onEnded { value in
+                    settle(value)
+                    // Cleared late: the tap lands on the same release as the drag's end.
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(150))
+                        isSwiping = false
+                    }
+                }
         )
     }
 

--- a/Splitty/Splitty/Components/SwipeToDeleteRow.swift
+++ b/Splitty/Splitty/Components/SwipeToDeleteRow.swift
@@ -1,0 +1,83 @@
+//
+//  SwipeToDeleteRow.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// A row that reveals a delete action when dragged left.
+///
+/// Not `.swipeActions`: the system draws its button as a rounded, inset shape, and these
+/// rows are square and edge to edge. The gesture is the same one — drag to reveal, tap to
+/// act, full swipe to act directly — so what changes is the shape, not the behaviour.
+struct SwipeToDeleteRow<Content: View>: View {
+    let onDelete: () -> Void
+    @ViewBuilder var content: Content
+
+    @State private var offset: CGFloat = 0
+    @GestureState private var translation: CGFloat = 0
+
+    private static var actionWidth: CGFloat { 88 }
+    /// Past this the row commits on release, the way a full swipe does in a system list.
+    private static var commitWidth: CGFloat { 260 }
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            Button(action: delete) {
+                Image(systemName: "trash")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.white)
+                    .frame(width: Self.actionWidth)
+                    .frame(maxHeight: .infinity)
+                    .background(Color.red)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete")
+
+            content
+                .background(Color("card"))
+                .offset(x: shownOffset)
+        }
+        .animation(.snappy(duration: 0.25), value: offset)
+        .gesture(
+            DragGesture(minimumDistance: 12)
+                .updating($translation) { value, state, _ in
+                    // Vertical intent belongs to the list, so only the horizontal part of a
+                    // drag that is mostly horizontal is taken.
+                    guard abs(value.translation.width) > abs(value.translation.height) else {
+                        return
+                    }
+                    state = value.translation.width
+                }
+                .onEnded(settle)
+        )
+    }
+
+    /// Clamped: the row opens to the action's width and resists past it, and never drags
+    /// right of its resting place.
+    private var shownOffset: CGFloat {
+        let raw = offset + translation
+        if raw > 0 { return 0 }
+        return raw < -Self.actionWidth
+            ? -Self.actionWidth + (raw + Self.actionWidth) / 3
+            : raw
+    }
+
+    private func settle(_ value: DragGesture.Value) {
+        guard abs(value.translation.width) > abs(value.translation.height) else { return }
+
+        let travelled = offset + value.translation.width
+
+        if travelled < -Self.commitWidth {
+            offset = 0
+            onDelete()
+        } else {
+            offset = travelled < -Self.actionWidth / 2 ? -Self.actionWidth : 0
+        }
+    }
+
+    private func delete() {
+        offset = 0
+        onDelete()
+    }
+}

--- a/Splitty/Splitty/Models/AmountExpression.swift
+++ b/Splitty/Splitty/Models/AmountExpression.swift
@@ -1,0 +1,181 @@
+//
+//  AmountExpression.swift
+//  Splitty
+//
+
+import Foundation
+
+/// The four operations the keypad offers.
+enum CalculatorOperator: CaseIterable {
+    case add
+    case subtract
+    case multiply
+    case divide
+
+    var symbol: String {
+        switch self {
+        case .add: return "+"
+        case .subtract: return "−"
+        case .multiply: return "×"
+        case .divide: return "÷"
+        }
+    }
+}
+
+/// The amount field's state machine: what has been typed, plus at most one pending
+/// operation.
+///
+/// Arithmetic is **chained left to right with no precedence** — `2 + 3 × 4` is `20`.
+/// Precedence without visible parentheses produces an answer that looks wrong and cannot
+/// be diagnosed from the one line of digits on screen.
+///
+/// Values are held as `Decimal` and rounded to the cent only when read, so a chain of
+/// operations does not accumulate binary floating-point drift on its way to a total that
+/// the splits have to match exactly.
+struct AmountExpression: Equatable {
+    /// The number currently being typed. `nil` means the next digit starts a fresh one,
+    /// and the display falls back to `accumulator`.
+    private var entry: String?
+    private var accumulator: Decimal = 0
+
+    /// Visible so the pad can highlight the operator that is waiting for its right operand.
+    private(set) var pendingOperator: CalculatorOperator?
+
+    /// Two decimal places, because a third digit is not an amount of money anyone can pay.
+    private static let fractionLimit = 2
+
+    /// Enough digits for any real expense, and short of anything that would overflow the
+    /// conversion to cents.
+    private static let integerLimit = 9
+
+    init() {}
+
+    /// Seeds the field when an existing expense is reopened.
+    init(cents: Int) {
+        entry = Self.format(Decimal(cents) / 100)
+    }
+
+    // MARK: - Reading
+
+    var displayText: String {
+        entry ?? Self.format(accumulator)
+    }
+
+    /// True while an operator is waiting for its right operand. Save auto-evaluates rather
+    /// than refusing to save a number the app can compute.
+    var hasPendingExpression: Bool { pendingOperator != nil }
+
+    /// The value of the whole expression, pending operation included, in cents.
+    var resolvedCents: Int {
+        Money.cents(from: resolved)
+    }
+
+    private var resolved: Decimal {
+        guard let pendingOperator else { return entryValue ?? accumulator }
+        guard let right = entryValue else { return accumulator }
+        return Self.combine(accumulator, pendingOperator, right) ?? accumulator
+    }
+
+    private var entryValue: Decimal? {
+        guard let entry else { return nil }
+        // A trailing point ("7.") is a display state, not a number; Decimal parses it anyway.
+        return Decimal(string: entry, locale: Locale(identifier: "en_US_POSIX"))
+    }
+
+    // MARK: - Entry
+
+    mutating func type(digit: Int) {
+        guard (0...9).contains(digit) else { return }
+
+        guard var text = entry else {
+            entry = "\(digit)"
+            return
+        }
+
+        if text == "0" {
+            entry = "\(digit)"
+            return
+        }
+
+        if let pointIndex = text.firstIndex(of: ".") {
+            let fractionDigits = text.distance(from: text.index(after: pointIndex), to: text.endIndex)
+            guard fractionDigits < Self.fractionLimit else { return }
+        } else {
+            guard text.count < Self.integerLimit else { return }
+        }
+
+        text.append("\(digit)")
+        entry = text
+    }
+
+    mutating func typeDecimalPoint() {
+        guard let text = entry else {
+            entry = "0."
+            return
+        }
+        guard !text.contains(".") else { return }
+        entry = text + "."
+    }
+
+    mutating func backspace() {
+        // After an evaluation the result lives in the accumulator; deleting from it is
+        // what someone who mistyped the last digit expects.
+        if entry == nil, pendingOperator == nil, accumulator != 0 {
+            entry = Self.format(accumulator)
+            accumulator = 0
+        }
+
+        guard var text = entry else { return }
+        text.removeLast()
+        entry = text.isEmpty ? nil : text
+    }
+
+    mutating func clear() {
+        entry = nil
+        accumulator = 0
+        pendingOperator = nil
+    }
+
+    /// Replaces the whole entry — the clipboard chip, which offers a price rather than a
+    /// digit to append.
+    mutating func replaceEntry(cents: Int) {
+        entry = Self.format(Decimal(cents) / 100)
+        accumulator = 0
+        pendingOperator = nil
+    }
+
+    // MARK: - Arithmetic
+
+    mutating func apply(_ operation: CalculatorOperator) {
+        if let right = entryValue {
+            accumulator = pendingOperator.flatMap { Self.combine(accumulator, $0, right) } ?? right
+            entry = nil
+        }
+        pendingOperator = operation
+    }
+
+    mutating func evaluate() {
+        accumulator = resolved
+        entry = nil
+        pendingOperator = nil
+    }
+
+    /// `nil` when the operation has no answer to show — only division by zero, which
+    /// leaves the left operand standing rather than inventing a result.
+    private static func combine(_ left: Decimal, _ operation: CalculatorOperator, _ right: Decimal) -> Decimal? {
+        switch operation {
+        case .add: return left + right
+        case .subtract: return left - right
+        case .multiply: return left * right
+        case .divide: return right == 0 ? nil : left / right
+        }
+    }
+
+    // MARK: - Formatting
+
+    /// Whole amounts read as `42`, not `42.00`: the trailing zeros are noise while typing.
+    private static func format(_ value: Decimal) -> String {
+        let cents = Money.cents(from: value)
+        return Money.plainString(cents: cents)
+    }
+}

--- a/Splitty/Splitty/Models/AmountExpression.swift
+++ b/Splitty/Splitty/Models/AmountExpression.swift
@@ -77,9 +77,9 @@ struct AmountExpression: Equatable {
     }
 
     private var entryValue: Decimal? {
-        guard let entry else { return nil }
-        // A trailing point ("7.") is a display state, not a number; Decimal parses it anyway.
-        return Decimal(string: entry, locale: Locale(identifier: "en_US_POSIX"))
+        // A trailing point ("7.") is a display state, not a number; parsing reads it as 7.
+        guard let entry, let cents = Money.cents(fromTypedText: entry) else { return nil }
+        return Decimal(cents) / 100
     }
 
     // MARK: - Entry

--- a/Splitty/Splitty/Models/Expense.swift
+++ b/Splitty/Splitty/Models/Expense.swift
@@ -21,6 +21,10 @@ struct Expense: Codable, Identifiable {
     let amount: Double
     let description: String
     let type: ExpenseType
+    /// When the expense happened, as the user says it did. Nullable: rows written before
+    /// the column existed have no user-supplied date, so every reader falls back to
+    /// `createdAt`.
+    let date: String?
     let createdAt: String
     let updatedAt: String
     let paidByUser: User
@@ -45,42 +49,43 @@ struct GroupedExpense {
 
 // MARK: - Extensions for Date Formatting and Calculations
 extension Expense {
-    var formattedDate: Date? {
-        // Use ISO8601DateFormatter for robust parsing
+    /// The date the expense is filed under: the user-supplied one when there is one, the
+    /// audit timestamp otherwise.
+    var effectiveDate: Date? {
+        Self.parseTimestamp(date ?? createdAt)
+    }
+
+    /// Parses the API's ISO-8601 timestamps, with and without fractional seconds.
+    static func parseTimestamp(_ value: String) -> Date? {
         let iso8601Formatter = ISO8601DateFormatter()
         iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        
-        if let date = iso8601Formatter.date(from: createdAt) {
+
+        if let date = iso8601Formatter.date(from: value) {
             return date
         }
-        
-        // Fallback to without fractional seconds
+
         iso8601Formatter.formatOptions = [.withInternetDateTime]
-        if let date = iso8601Formatter.date(from: createdAt) {
+        if let date = iso8601Formatter.date(from: value) {
             return date
         }
-        
-        // Last resort: try manual DateFormatter
+
+        // Timestamps serialized without a zone marker are UTC, like every other one.
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(identifier: "UTC")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        
-        // Strip fractional seconds if present
-        var cleanedDate = createdAt
-        if let dotRange = createdAt.range(of: "\\.\\d+Z", options: .regularExpression) {
-            cleanedDate = createdAt.replacingCharacters(in: dotRange, with: "Z")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+        var cleaned = value
+        if let fractionRange = value.range(of: "\\.\\d+", options: .regularExpression) {
+            cleaned = value.replacingCharacters(in: fractionRange, with: "")
         }
-        
-        if let date = formatter.date(from: cleanedDate) {
-            return date
-        }
-        
-        print("❌ Failed to parse date: \(createdAt)")
-        return nil
+        cleaned = cleaned.replacingOccurrences(of: "Z", with: "")
+
+        return formatter.date(from: cleaned)
     }
-    
+
     var dayString: String {
-        guard let date = formattedDate else { return "Unknown" }
+        guard let date = effectiveDate else { return "Unknown" }
         
         let calendar = Calendar.current
         if calendar.isDateInToday(date) {
@@ -119,14 +124,14 @@ extension Expense {
         let calendar = Calendar.current
         
         let grouped = Dictionary(grouping: expenses) { expense in
-            guard let date = expense.formattedDate else { return Date.distantPast }
+            guard let date = expense.effectiveDate else { return Date.distantPast }
             return calendar.startOfDay(for: date)
         }
         
         return grouped.compactMap { (date, expenses) in
             let sortedExpenses = expenses.sorted { expense1, expense2 in
-                guard let date1 = expense1.formattedDate,
-                      let date2 = expense2.formattedDate else { return false }
+                guard let date1 = expense1.effectiveDate,
+                      let date2 = expense2.effectiveDate else { return false }
                 return date1 > date2
             }
             

--- a/Splitty/Splitty/Models/Expense.swift
+++ b/Splitty/Splitty/Models/Expense.swift
@@ -99,6 +99,12 @@ extension Expense {
         }
     }
     
+    /// The counterparty on a settlement: the split that is not the payer's, which is the
+    /// shape every settlement is built with (`[+amount, -amount]`).
+    var peer: User? {
+        splits.first { $0.userId != paidBy }?.user
+    }
+
     // Calculate the expense split for the current user
     func getUserSplit(currentUserId: Int) -> Double {
         // Find the current user's split

--- a/Splitty/Splitty/Models/Money.swift
+++ b/Splitty/Splitty/Models/Money.swift
@@ -1,0 +1,50 @@
+//
+//  Money.swift
+//  Splitty
+//
+
+import Foundation
+
+/// Amounts in integer cents.
+///
+/// The API validates that splits sum **exactly** to the total against a `decimal` column.
+/// Deriving splits in `Double` makes that a coin flip; deriving them in cents makes it a
+/// property of the arithmetic. Conversion happens once, at the request boundary.
+enum Money {
+    static func cents(from value: Decimal) -> Int {
+        var rounded = Decimal()
+        var scaled = value * 100
+        NSDecimalRound(&rounded, &scaled, 0, .plain)
+        return NSDecimalNumber(decimal: rounded).intValue
+    }
+
+    static func cents(from value: Double) -> Int {
+        cents(from: Decimal(value))
+    }
+
+    static func amount(cents: Int) -> Double {
+        Double(cents) / 100
+    }
+
+    /// `42`, `42.50` — for a field being typed into, where trailing zeros are noise.
+    static func plainString(cents: Int) -> String {
+        let sign = cents < 0 ? "-" : ""
+        let magnitude = abs(cents)
+        let whole = magnitude / 100
+        let fraction = magnitude % 100
+        return fraction == 0
+            ? "\(sign)\(whole)"
+            : "\(sign)\(whole).\(String(format: "%02d", fraction))"
+    }
+
+    /// `$42.50` — for anything being read rather than typed. Currency is a hardcoded `$`.
+    static func formatted(cents: Int) -> String {
+        let sign = cents < 0 ? "-" : ""
+        let magnitude = abs(cents)
+        return "\(sign)$\(magnitude / 100).\(String(format: "%02d", magnitude % 100))"
+    }
+
+    static func formatted(amount: Double) -> String {
+        formatted(cents: cents(from: amount))
+    }
+}

--- a/Splitty/Splitty/Models/Money.swift
+++ b/Splitty/Splitty/Models/Money.swift
@@ -22,6 +22,15 @@ enum Money {
         cents(from: Decimal(value))
     }
 
+    /// Reads what someone typed into an amount field. Always `en_US_POSIX`: the pad and the
+    /// keyboard both produce a `.` regardless of locale.
+    static func cents(fromTypedText text: String) -> Int? {
+        guard let value = Decimal(string: text, locale: Locale(identifier: "en_US_POSIX")) else {
+            return nil
+        }
+        return cents(from: value)
+    }
+
     static func amount(cents: Int) -> Double {
         Double(cents) / 100
     }

--- a/Splitty/Splitty/Models/Money.swift
+++ b/Splitty/Splitty/Models/Money.swift
@@ -35,6 +35,17 @@ enum Money {
         Double(cents) / 100
     }
 
+    /// The value to put in a request body.
+    ///
+    /// Not `Double`: `JSONSerialization` prints a double to 17 significant digits, so 8.33
+    /// goes out as `8.3300000000000001`, and the API parses that into a `decimal` that
+    /// keeps every one of those digits. Three of them no longer sum to 25 and the request
+    /// is rejected for splits that are, in cents, exact. `NSDecimalNumber` prints the
+    /// decimal it holds.
+    static func requestValue(cents: Int) -> NSDecimalNumber {
+        NSDecimalNumber(decimal: Decimal(cents) / 100)
+    }
+
     /// `42`, `42.50` — for a field being typed into, where trailing zeros are noise.
     static func plainString(cents: Int) -> String {
         let sign = cents < 0 ? "-" : ""

--- a/Splitty/Splitty/Models/SplitConfiguration.swift
+++ b/Splitty/Splitty/Models/SplitConfiguration.swift
@@ -1,0 +1,225 @@
+//
+//  SplitConfiguration.swift
+//  Splitty
+//
+
+import Foundation
+
+/// How the per-user amounts were derived. A client-only concept: the API takes absolute
+/// amounts and stores no mode, so this never leaves the device.
+enum SplitMode: Equatable {
+    /// Divided evenly across the checked members.
+    case equal(participants: Set<Int>)
+    /// Typed per person, in cents.
+    case custom(amounts: [Int: Int])
+}
+
+/// Why Save is unavailable. Only locally-provable violations appear here; anything that
+/// depends on server state is left to the server's `400`.
+enum SplitBlock: Equatable {
+    case amountNotPositive
+    case noParticipants
+    /// Positive when the custom amounts fall short of the total, negative when they exceed it.
+    case unassigned(cents: Int)
+}
+
+/// Who paid and who owes, in integer cents.
+struct SplitConfiguration: Equatable {
+    var payerId: Int
+    var mode: SplitMode
+
+    init(payerId: Int, mode: SplitMode) {
+        self.payerId = payerId
+        self.mode = mode
+    }
+
+    // MARK: - Equal division
+
+    /// Divides `totalCents` across `userIds`, giving the remainder cents to the first
+    /// participants by **ascending user id**. Deterministic and device-independent; giving
+    /// them to the payer instead would bias one person across many expenses.
+    static func equalAmounts(totalCents: Int, among userIds: some Collection<Int>) -> [Int: Int] {
+        guard !userIds.isEmpty, totalCents > 0 else { return [:] }
+
+        let ordered = userIds.sorted()
+        let base = totalCents / ordered.count
+        let remainder = totalCents % ordered.count
+
+        return Dictionary(uniqueKeysWithValues: ordered.enumerated().map { index, userId in
+            (userId, base + (index < remainder ? 1 : 0))
+        })
+    }
+
+    // MARK: - Resolving
+
+    /// The amount each participant owes, in cents.
+    func amounts(totalCents: Int) -> [Int: Int] {
+        switch mode {
+        case .equal(let participants):
+            return Self.equalAmounts(totalCents: totalCents, among: participants)
+        case .custom(let amounts):
+            return amounts
+        }
+    }
+
+    /// The payload. A participant who lands on zero is **omitted** rather than sent as `0`:
+    /// the API rejects a split that is not greater than zero.
+    func splits(totalCents: Int) -> [ExpenseSplitRequest] {
+        amounts(totalCents: totalCents)
+            .filter { $0.value > 0 }
+            .sorted { $0.key < $1.key }
+            .map { ExpenseSplitRequest(userId: $0.key, amount: Money.amount(cents: $0.value)) }
+    }
+
+    /// What is left to assign on a custom split — the exact-sum invariant rendered as a
+    /// progress readout instead of a validation error.
+    func unassignedCents(totalCents: Int) -> Int {
+        guard case .custom(let amounts) = mode else { return 0 }
+        return totalCents - amounts.values.reduce(0, +)
+    }
+
+    func blockingReason(totalCents: Int) -> SplitBlock? {
+        guard totalCents > 0 else { return .amountNotPositive }
+
+        switch mode {
+        case .equal(let participants):
+            return participants.isEmpty ? .noParticipants : nil
+        case .custom:
+            let unassigned = unassignedCents(totalCents: totalCents)
+            return unassigned == 0 ? nil : .unassigned(cents: unassigned)
+        }
+    }
+
+    // MARK: - Reopening
+
+    /// The API stores no split mode, so it is inferred: **equal** when the stored amounts
+    /// match within a cent — a remainder cent is still an equal split — and **custom**
+    /// otherwise. A wrong inference is harmless: the real stored amounts are on screen
+    /// either way.
+    init(inferredFrom expense: Expense) {
+        payerId = expense.paidBy
+
+        let amounts = Dictionary(
+            uniqueKeysWithValues: expense.splits.map { ($0.userId, Money.cents(from: $0.amount)) }
+        )
+
+        guard let lowest = amounts.values.min(), let highest = amounts.values.max() else {
+            mode = .equal(participants: [])
+            return
+        }
+
+        mode = highest - lowest <= 1
+            ? .equal(participants: Set(amounts.keys))
+            : .custom(amounts: amounts)
+    }
+
+    // MARK: - Summary
+
+    /// The line the sheet shows in place of the split screen.
+    func summary(members: [GroupMember], currentUserId: Int) -> String {
+        let payer = payerId == currentUserId
+            ? "you"
+            : members.first { $0.userId == payerId }?.name ?? "someone else"
+
+        switch mode {
+        case .custom:
+            return "Paid by \(payer) and split by amounts"
+        case .equal(let participants):
+            if participants.count == 1, let onlyId = participants.first, onlyId != payerId {
+                let debtor = onlyId == currentUserId
+                    ? "you owe"
+                    : "\(members.first { $0.userId == onlyId }?.name ?? "they") owes"
+                return "Paid by \(payer), \(debtor) the full amount"
+            }
+            if participants.count == members.count || members.isEmpty {
+                return "Paid by \(payer) and split equally"
+            }
+            return "Paid by \(payer) and split equally between \(participants.count) people"
+        }
+    }
+}
+
+/// A named starting point on the split screen: payer and mode in one tap.
+enum SplitPreset: Hashable, CaseIterable, Identifiable {
+    case youPaidSplitEqually
+    case someoneElsePaidSplitEqually
+    case youPaidTheyOweFull
+    case theyPaidYouOweFull
+    case custom
+
+    var id: Self { self }
+
+    /// "Owes the full amount" is offered only to two-person groups. In a larger group it
+    /// would need a target picker, which is a custom split with extra steps.
+    static func available(memberIds: [Int], currentUserId: Int) -> [SplitPreset] {
+        allCases.filter { preset in
+            switch preset {
+            case .youPaidTheyOweFull, .theyPaidYouOweFull:
+                return memberIds.count == 2 && memberIds.contains(currentUserId)
+            default:
+                return true
+            }
+        }
+    }
+
+    func title(members: [GroupMember], currentUserId: Int) -> String {
+        switch self {
+        case .youPaidSplitEqually: return "You paid, split equally"
+        case .someoneElsePaidSplitEqually: return "Someone else paid, split equally"
+        case .youPaidTheyOweFull:
+            return "You paid, \(Self.otherName(members: members, currentUserId: currentUserId)) owes the full amount"
+        case .theyPaidYouOweFull:
+            return "\(Self.otherName(members: members, currentUserId: currentUserId)) paid, you owe the full amount"
+        case .custom: return "Custom"
+        }
+    }
+
+    /// `payerId` only matters for `someoneElsePaidSplitEqually`; the others derive the
+    /// payer from the preset itself.
+    func configuration(memberIds: [Int], currentUserId: Int, payerId: Int? = nil) -> SplitConfiguration {
+        let others = memberIds.filter { $0 != currentUserId }.sorted()
+
+        switch self {
+        case .youPaidSplitEqually:
+            return SplitConfiguration(payerId: currentUserId, mode: .equal(participants: Set(memberIds)))
+        case .someoneElsePaidSplitEqually:
+            return SplitConfiguration(
+                payerId: payerId ?? others.first ?? currentUserId,
+                mode: .equal(participants: Set(memberIds))
+            )
+        case .youPaidTheyOweFull:
+            return SplitConfiguration(payerId: currentUserId, mode: .equal(participants: Set(others)))
+        case .theyPaidYouOweFull:
+            return SplitConfiguration(
+                payerId: others.first ?? currentUserId,
+                mode: .equal(participants: [currentUserId])
+            )
+        case .custom:
+            return SplitConfiguration(payerId: payerId ?? currentUserId, mode: .custom(amounts: [:]))
+        }
+    }
+
+    /// Which preset a configuration reads as, so the split screen can show the one in
+    /// effect rather than always starting from the default.
+    static func matching(
+        _ configuration: SplitConfiguration,
+        memberIds: [Int],
+        currentUserId: Int
+    ) -> SplitPreset? {
+        // A custom split carries amounts a preset cannot reproduce, so it is recognised by
+        // its mode rather than by rebuilding it.
+        if case .custom = configuration.mode { return .custom }
+
+        return available(memberIds: memberIds, currentUserId: currentUserId).first { preset in
+            preset != .custom && preset.configuration(
+                memberIds: memberIds,
+                currentUserId: currentUserId,
+                payerId: configuration.payerId
+            ) == configuration
+        }
+    }
+
+    private static func otherName(members: [GroupMember], currentUserId: Int) -> String {
+        members.first { $0.userId != currentUserId }?.name ?? "they"
+    }
+}

--- a/Splitty/Splitty/Models/SplitConfiguration.swift
+++ b/Splitty/Splitty/Models/SplitConfiguration.swift
@@ -68,7 +68,7 @@ struct SplitConfiguration: Equatable {
         amounts(totalCents: totalCents)
             .filter { $0.value > 0 }
             .sorted { $0.key < $1.key }
-            .map { ExpenseSplitRequest(userId: $0.key, amount: Money.amount(cents: $0.value)) }
+            .map { ExpenseSplitRequest(userId: $0.key, amountCents: $0.value) }
     }
 
     /// What is left to assign on a custom split — the exact-sum invariant rendered as a

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -74,7 +74,7 @@ class APIClient {
                         NotificationCenter.default.post(name: .unauthorizedError, object: nil)
                     }
                 }
-                throw APIError.httpError(httpResponse.statusCode)
+                throw APIError.httpError(httpResponse.statusCode, message: Self.serverMessage(from: data))
             }
             
             // A 204 carries no body; decoding one is a failure that has nothing to report.
@@ -101,6 +101,25 @@ class APIClient {
         }
     }
     
+    /// The server's explanation for a rejection, from either error shape the API produces:
+    /// its own `ErrorResponse`, or the validation dictionary `ModelState` returns.
+    private static func serverMessage(from data: Data) -> String? {
+        guard !data.isEmpty,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        if let message = json["message"] as? String, !message.isEmpty {
+            return message
+        }
+
+        if let errors = json["errors"] as? [String: Any] {
+            let messages = errors.values.compactMap { $0 as? [String] }.flatMap { $0 }
+            if !messages.isEmpty { return messages.joined(separator: " ") }
+        }
+
+        return nil
+    }
+
     // MARK: - Authentication
     /// Redeems a one-time Google auth code for a Splitty token. The exchange with Google
     /// happens server-side, so no client secret is needed here.
@@ -163,10 +182,28 @@ enum APIError: Error, LocalizedError {
     case noAuthToken
     case invalidRequestBody
     case invalidResponse
-    case httpError(Int)
+    /// `message` is the server's own explanation, when it sent one. A rejected split is the
+    /// case that needs it: only the server knows why a request the client believed in was
+    /// refused.
+    case httpError(Int, message: String?)
     case networkError(Error)
     case decodingError(Error)
     
+    /// What to put on screen. The server's own `400` is the only thing that knows why a
+    /// request the client believed in was refused, so it gets its own line rather than a
+    /// raw `localizedDescription`.
+    var displayMessage: String {
+        switch self {
+        case .httpError(_, .some(let message)): return message
+        case .httpError(400, _): return "The server rejected this. Check the amounts and try again."
+        case .httpError(403, _): return "You are not a member of this group."
+        case .httpError(404, _): return "This no longer exists."
+        case .httpError(let status, _): return "Something went wrong (\(status)). Try again."
+        case .networkError: return "Couldn't reach Splitty. Check your connection and try again."
+        default: return errorDescription ?? "Something went wrong. Try again."
+        }
+    }
+
     var errorDescription: String? {
         switch self {
         case .missingBaseURL:
@@ -181,13 +218,20 @@ enum APIError: Error, LocalizedError {
             return "Invalid request body"
         case .invalidResponse:
             return "Invalid response"
-        case .httpError(let code):
+        case .httpError(let code, _):
             return "HTTP error: \(code)"
         case .networkError(let error):
             return "Network error: \(error.localizedDescription)"
         case .decodingError(let error):
             return "Decoding error: \(error.localizedDescription)"
         }
+    }
+}
+
+extension Error {
+    /// Non-`APIError` failures have no copy of their own to offer.
+    var displayMessage: String {
+        (self as? APIError)?.displayMessage ?? localizedDescription
     }
 }
 

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -238,7 +238,7 @@ extension Error {
 // MARK: - Request Types
 struct ExpenseSplitRequest {
     let userId: Int
-    let amount: Double
+    let amountCents: Int
 }
 
 // MARK: - Response Types

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -25,7 +25,9 @@ class APIClient {
     }
     
     // MARK: - Generic Request Method
-    private func request<T: Codable>(
+    /// Not private: a service owns its own endpoints and calls this directly rather than
+    /// adding another pass-through method here.
+    func request<T: Codable>(
         endpoint: String,
         method: HTTPMethod = .GET,
         body: [String: Any]? = nil,
@@ -75,6 +77,11 @@ class APIClient {
                 throw APIError.httpError(httpResponse.statusCode)
             }
             
+            // A 204 carries no body; decoding one is a failure that has nothing to report.
+            if data.isEmpty, let empty = EmptyResponse() as? T {
+                return empty
+            }
+
             let decoder = JSONDecoder()
             do {
                 return try decoder.decode(T.self, from: data)
@@ -141,62 +148,11 @@ class APIClient {
         return try await request(endpoint: "/invite/\(code)/accept", method: .POST)
     }
     
-    // MARK: - Expenses
-    func getExpenses(groupId: Int) async throws -> [Expense] {
-        return try await request(endpoint: "/group/\(groupId)/expenses")
-    }
-    
-    func getExpense(groupId: Int, expenseId: Int) async throws -> Expense {
-        return try await request(endpoint: "/group/\(groupId)/expenses/\(expenseId)")
-    }
-    
-    func createExpense(
-        groupId: Int,
-        description: String,
-        amount: Double,
-        paidBy: Int,
-        splits: [ExpenseSplitRequest]
-    ) async throws -> Expense {
-        let body: [String: Any] = [
-            "groupId": groupId,
-            "description": description,
-            "amount": amount,
-            "paidBy": paidBy,
-            "splits": splits.map { ["userId": $0.userId, "amount": $0.amount] }
-        ]
-        return try await request(endpoint: "/group/\(groupId)/expenses", method: .POST, body: body)
-    }
-    
-    func updateExpense(
-        groupId: Int,
-        expenseId: Int,
-        description: String?,
-        amount: Double?,
-        splits: [ExpenseSplitRequest]?
-    ) async throws -> Expense {
-        var body: [String: Any] = [:]
-        if let description = description { body["description"] = description }
-        if let amount = amount { body["amount"] = amount }
-        if let splits = splits {
-            body["splits"] = splits.map { ["userId": $0.userId, "amount": $0.amount] }
-        }
-        return try await request(endpoint: "/group/\(groupId)/expenses/\(expenseId)", method: .PUT, body: body)
-    }
-    
-    func deleteExpense(groupId: Int, expenseId: Int) async throws {
-        let _: EmptyResponse = try await request(endpoint: "/group/\(groupId)/expenses/\(expenseId)", method: .DELETE)
-    }
-    
     // MARK: - Users/Profile
+    /// The profile route is `GET /auth`, not `/profile` — there has never been a
+    /// `/profile` route to call.
     func getProfile() async throws -> User {
-        return try await request(endpoint: "/profile")
-    }
-    
-    func updateProfile(name: String?, email: String?) async throws -> User {
-        var body: [String: Any] = [:]
-        if let name = name { body["name"] = name }
-        if let email = email { body["email"] = email }
-        return try await request(endpoint: "/profile", method: .PUT, body: body)
+        return try await request(endpoint: "/auth")
     }
 }
 
@@ -270,6 +226,13 @@ struct GroupMembership: Codable, Identifiable {
     let groupId: Int
     let joinedAt: String
     let user: User
+}
+
+/// `GET /group/{id}/expenses/summary`. Only the flag is decoded: the header reads its
+/// number from the group itself, and the pairwise rows have no screen yet.
+struct GroupBalanceSummary: Codable {
+    /// A display hint only: true while a recomputation is queued or in flight.
+    let balancesPending: Bool
 }
 
 struct Balance: Codable {

--- a/Splitty/Splitty/Services/AuthenticationManager.swift
+++ b/Splitty/Splitty/Services/AuthenticationManager.swift
@@ -8,9 +8,16 @@
 import Foundation
 import SwiftUI
 
+@MainActor
 class AuthenticationManager: ObservableObject {
     @Published var isAuthenticated = false
-    
+
+    /// Who is signed in. Everything that says "you" — the default payer, the checkbox
+    /// defaults, whether a row reads *lent* or *borrowed* — reads this. Not cached in
+    /// UserDefaults: the token already lives in the Keychain, and one request on launch
+    /// cannot go stale the way a second copy of the profile can.
+    @Published var currentUser: User?
+
     static let shared = AuthenticationManager()
     
     private init() {
@@ -25,7 +32,7 @@ class AuthenticationManager: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             print("🔴 Received 401 unauthorized - forcing logout")
-            self?.logout()
+            Task { @MainActor in self?.logout() }
         }
     }
     
@@ -33,12 +40,27 @@ class AuthenticationManager: ObservableObject {
         isAuthenticated = AuthService.shared.isAuthenticated()
     }
     
-    func login() {
+    func login(user: User) {
+        currentUser = user
         isAuthenticated = true
     }
-    
+
+    /// Fills in `currentUser` on a cold launch that skipped the sign-in screen. A failure
+    /// leaves the session alone: a 401 already forces a logout through the notification,
+    /// and anything else is a network blip that a later screen can retry.
+    func hydrateCurrentUser() async {
+        guard isAuthenticated, currentUser == nil else { return }
+
+        do {
+            currentUser = try await AuthService.shared.getCurrentUser()
+        } catch {
+            print("⚠️ Could not load the signed-in profile: \(error.localizedDescription)")
+        }
+    }
+
     func logout() {
         AuthService.shared.logout()
+        currentUser = nil
         isAuthenticated = false
     }
 }

--- a/Splitty/Splitty/Services/ExpenseService.swift
+++ b/Splitty/Splitty/Services/ExpenseService.swift
@@ -13,11 +13,11 @@ class ExpenseService {
     private init() {}
     
     func getExpenses(groupId: Int) async throws -> [Expense] {
-        return try await APIClient.shared.getExpenses(groupId: groupId)
+        try await APIClient.shared.request(endpoint: "/group/\(groupId)/expenses")
     }
     
     func getExpense(groupId: Int, expenseId: Int) async throws -> Expense {
-        return try await APIClient.shared.getExpense(groupId: groupId, expenseId: expenseId)
+        try await APIClient.shared.request(endpoint: "/group/\(groupId)/expenses/\(expenseId)")
     }
     
     func createExpense(
@@ -25,14 +25,22 @@ class ExpenseService {
         description: String,
         amount: Double,
         paidBy: Int,
+        date: Date?,
         splits: [ExpenseSplitRequest]
     ) async throws -> Expense {
-        return try await APIClient.shared.createExpense(
-            groupId: groupId,
-            description: description,
-            amount: amount,
-            paidBy: paidBy,
-            splits: splits
+        var body: [String: Any] = [
+            "groupId": groupId,
+            "description": description,
+            "amount": amount,
+            "paidBy": paidBy,
+            "splits": splits.map { ["userId": $0.userId, "amount": $0.amount] }
+        ]
+        if let date { body["date"] = Self.timestamp(from: date) }
+
+        return try await APIClient.shared.request(
+            endpoint: "/group/\(groupId)/expenses",
+            method: .POST,
+            body: body
         )
     }
     
@@ -41,18 +49,41 @@ class ExpenseService {
         expenseId: Int,
         description: String? = nil,
         amount: Double? = nil,
+        paidBy: Int? = nil,
+        date: Date? = nil,
         splits: [ExpenseSplitRequest]? = nil
     ) async throws -> Expense {
-        return try await APIClient.shared.updateExpense(
-            groupId: groupId,
-            expenseId: expenseId,
-            description: description,
-            amount: amount,
-            splits: splits
+        var body: [String: Any] = [:]
+        if let description { body["description"] = description }
+        if let amount { body["amount"] = amount }
+        if let paidBy { body["paidBy"] = paidBy }
+        if let date { body["date"] = Self.timestamp(from: date) }
+        if let splits {
+            body["splits"] = splits.map { ["userId": $0.userId, "amount": $0.amount] }
+        }
+
+        return try await APIClient.shared.request(
+            endpoint: "/group/\(groupId)/expenses/\(expenseId)",
+            method: .PUT,
+            body: body
         )
     }
     
+    /// The expense routes refuse `payment` rows; a settlement is deleted through
+    /// `SettlementService`.
     func deleteExpense(groupId: Int, expenseId: Int) async throws {
-        return try await APIClient.shared.deleteExpense(groupId: groupId, expenseId: expenseId)
+        let _: EmptyResponse = try await APIClient.shared.request(
+            endpoint: "/group/\(groupId)/expenses/\(expenseId)",
+            method: .DELETE
+        )
+    }
+
+    /// UTC, no fractional seconds. The API reads a timestamp without an offset as already
+    /// UTC, so sending one with an offset is what keeps the stored instant unambiguous.
+    static func timestamp(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
     }
 }

--- a/Splitty/Splitty/Services/ExpenseService.swift
+++ b/Splitty/Splitty/Services/ExpenseService.swift
@@ -23,7 +23,7 @@ class ExpenseService {
     func createExpense(
         groupId: Int,
         description: String,
-        amount: Double,
+        amountCents: Int,
         paidBy: Int,
         date: Date?,
         splits: [ExpenseSplitRequest]
@@ -31,9 +31,11 @@ class ExpenseService {
         var body: [String: Any] = [
             "groupId": groupId,
             "description": description,
-            "amount": amount,
+            "amount": Money.requestValue(cents: amountCents),
             "paidBy": paidBy,
-            "splits": splits.map { ["userId": $0.userId, "amount": $0.amount] }
+            "splits": splits.map {
+                ["userId": $0.userId, "amount": Money.requestValue(cents: $0.amountCents)]
+            }
         ]
         if let date { body["date"] = Self.timestamp(from: date) }
 
@@ -48,18 +50,20 @@ class ExpenseService {
         groupId: Int,
         expenseId: Int,
         description: String? = nil,
-        amount: Double? = nil,
+        amountCents: Int? = nil,
         paidBy: Int? = nil,
         date: Date? = nil,
         splits: [ExpenseSplitRequest]? = nil
     ) async throws -> Expense {
         var body: [String: Any] = [:]
         if let description { body["description"] = description }
-        if let amount { body["amount"] = amount }
+        if let amountCents { body["amount"] = Money.requestValue(cents: amountCents) }
         if let paidBy { body["paidBy"] = paidBy }
         if let date { body["date"] = Self.timestamp(from: date) }
         if let splits {
-            body["splits"] = splits.map { ["userId": $0.userId, "amount": $0.amount] }
+            body["splits"] = splits.map {
+                ["userId": $0.userId, "amount": Money.requestValue(cents: $0.amountCents)]
+            }
         }
 
         return try await APIClient.shared.request(

--- a/Splitty/Splitty/Services/GroupService.swift
+++ b/Splitty/Splitty/Services/GroupService.swift
@@ -28,6 +28,12 @@ class GroupService {
         return try await APIClient.shared.updateGroup(id: id, name: name, description: description)
     }
     
+    /// Balances plus the pending flag. Recomputation is asynchronous, so right after a
+    /// money write the numbers are stale and `balancesPending` says so.
+    func getBalanceSummary(groupId: Int) async throws -> GroupBalanceSummary {
+        try await APIClient.shared.request(endpoint: "/group/\(groupId)/expenses/summary")
+    }
+
     /// Redeems an invite code. The response identifies the group — the caller never
     /// supplies a group id. Redeeming a code for a group you already belong to
     /// succeeds and returns that group.

--- a/Splitty/Splitty/Services/SettlementService.swift
+++ b/Splitty/Splitty/Services/SettlementService.swift
@@ -1,0 +1,22 @@
+//
+//  SettlementService.swift
+//  Splitty
+//
+
+import Foundation
+
+/// A settlement is stored as an `Expense` with `type == .payment`, but it is mutated
+/// through its own routes: the expense `PUT`/`DELETE` refuse payment rows rather than
+/// branching on a field the client never sent.
+class SettlementService {
+    static let shared = SettlementService()
+
+    private init() {}
+
+    func deleteSettlement(groupId: Int, expenseId: Int) async throws {
+        let _: EmptyResponse = try await APIClient.shared.request(
+            endpoint: "/group/\(groupId)/settlements/\(expenseId)",
+            method: .DELETE
+        )
+    }
+}

--- a/Splitty/Splitty/SplittyApp.swift
+++ b/Splitty/Splitty/SplittyApp.swift
@@ -44,6 +44,10 @@ struct RootView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             authManager.checkAuthenticationStatus()
             isCheckingAuth = false
+
+            // A launch that restores a Keychain token skips the sign-in screen, so this is
+            // the only place the profile gets loaded.
+            Task { await authManager.hydrateCurrentUser() }
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
+++ b/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
@@ -192,22 +192,8 @@ class ExpenseFormViewModel: ObservableObject {
                 splits: splits()
             )
         } catch {
-            errorMessage = Self.message(for: error)
+            errorMessage = error.displayMessage
             return nil
-        }
-    }
-
-    /// The server's `400` is the client's message: it is the only thing that knows why a
-    /// split the client believes in was refused.
-    static func message(for error: Error) -> String {
-        guard case APIError.httpError(let status) = error else {
-            return error.localizedDescription
-        }
-        switch status {
-        case 400: return "The server rejected this expense. Check the amounts and try again."
-        case 403: return "You are not a member of this group."
-        case 404: return "This expense no longer exists."
-        default: return "Something went wrong (\(status)). Try again."
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
+++ b/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
@@ -176,7 +176,7 @@ class ExpenseFormViewModel: ObservableObject {
                     groupId: groupId,
                     expenseId: expenseId,
                     description: trimmedDescription,
-                    amount: Money.amount(cents: total),
+                    amountCents: total,
                     paidBy: configuration.payerId,
                     date: date,
                     splits: splits()
@@ -186,7 +186,7 @@ class ExpenseFormViewModel: ObservableObject {
             return try await ExpenseService.shared.createExpense(
                 groupId: groupId,
                 description: trimmedDescription,
-                amount: Money.amount(cents: total),
+                amountCents: total,
                 paidBy: configuration.payerId,
                 date: date,
                 splits: splits()

--- a/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
+++ b/Splitty/Splitty/ViewModels/ExpenseFormViewModel.swift
@@ -1,0 +1,213 @@
+//
+//  ExpenseFormViewModel.swift
+//  Splitty
+//
+
+import Foundation
+
+/// Backs the sheet used for both creating and editing an expense. `expense` decides which
+/// of the two it is; everything else is identical.
+///
+/// The arithmetic lives in `AmountExpression` and `SplitConfiguration`; this holds the two
+/// together, decides when Save is available, and turns the result into a request.
+@MainActor
+class ExpenseFormViewModel: ObservableObject {
+    @Published var amount: AmountExpression
+    @Published var description: String
+    @Published var date: Date
+    @Published var configuration: SplitConfiguration
+    @Published var errorMessage: String?
+    @Published var isSaving = false
+
+    let groupId: Int
+    let members: [GroupMember]
+    let currentUserId: Int
+
+    private let existingExpenseId: Int?
+
+    init(groupId: Int, members: [GroupMember], currentUserId: Int, expense: Expense? = nil) {
+        self.groupId = groupId
+        self.members = members
+        self.currentUserId = currentUserId
+        self.existingExpenseId = expense?.id
+
+        if let expense {
+            amount = AmountExpression(cents: Money.cents(from: expense.amount))
+            description = expense.description
+            date = expense.effectiveDate ?? Date()
+            configuration = SplitConfiguration(inferredFrom: expense)
+        } else {
+            amount = AmountExpression()
+            description = ""
+            date = Date()
+            configuration = SplitConfiguration(
+                payerId: currentUserId,
+                mode: .equal(participants: Set(members.map(\.userId)))
+            )
+        }
+    }
+
+    // MARK: - Reading
+
+    var isEditing: Bool { existingExpenseId != nil }
+
+    var title: String { isEditing ? "Edit expense" : "New expense" }
+
+    var memberIds: [Int] { members.map(\.userId) }
+
+    /// The whole expression's value, pending operation included: Save auto-evaluates rather
+    /// than refusing to save a number the app can compute.
+    var totalCents: Int { amount.resolvedCents }
+
+    var splitSummary: String {
+        configuration.summary(members: members, currentUserId: currentUserId)
+    }
+
+    var selectedPreset: SplitPreset? {
+        SplitPreset.matching(configuration, memberIds: memberIds, currentUserId: currentUserId)
+    }
+
+    /// The per-person amounts as they stand, for the split screen's rows.
+    var perParticipantAmounts: [Int: Int] { configuration.amounts(totalCents: totalCents) }
+
+    /// Only locally-provable violations block Save. Everything else — anything that depends
+    /// on server state — is left to the server's `400`, rendered inline.
+    var canSave: Bool {
+        !isSaving
+            && !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && configuration.blockingReason(totalCents: totalCents) == nil
+    }
+
+    /// What is wrong with the *split*, in words. An amount of zero says so by being an
+    /// empty amount field, so it gets no message.
+    var blockingMessage: String? {
+        switch configuration.blockingReason(totalCents: totalCents) {
+        case .none, .amountNotPositive:
+            return nil
+        case .noParticipants:
+            return "Select who this is split between"
+        case .unassigned(let cents):
+            return cents > 0
+                ? "\(Money.formatted(cents: cents)) left to assign"
+                : "\(Money.formatted(cents: -cents)) over the total"
+        }
+    }
+
+    var isCustomSplit: Bool {
+        if case .custom = configuration.mode { return true }
+        return false
+    }
+
+    func isParticipant(_ userId: Int) -> Bool {
+        switch configuration.mode {
+        case .equal(let participants): return participants.contains(userId)
+        case .custom(let amounts): return (amounts[userId] ?? 0) > 0
+        }
+    }
+
+    func splits() -> [ExpenseSplitRequest] {
+        configuration.splits(totalCents: totalCents)
+    }
+
+    // MARK: - Split configuration
+
+    func apply(preset: SplitPreset, payerId: Int?) {
+        switch preset {
+        case .custom:
+            // Seeded from whatever the split currently is: adjusting two numbers beats
+            // typing every one of them.
+            configuration = SplitConfiguration(
+                payerId: payerId ?? configuration.payerId,
+                mode: .custom(amounts: perParticipantAmounts)
+            )
+        default:
+            configuration = preset.configuration(
+                memberIds: memberIds,
+                currentUserId: currentUserId,
+                payerId: payerId
+            )
+        }
+    }
+
+    /// Unchecking a member re-derives the split across the rest and drops them from the
+    /// payload; on a custom split it clears their row, which does the same thing.
+    func toggleParticipant(_ userId: Int) {
+        switch configuration.mode {
+        case .equal(var participants):
+            if participants.contains(userId) {
+                participants.remove(userId)
+            } else {
+                participants.insert(userId)
+            }
+            configuration.mode = .equal(participants: participants)
+        case .custom(var amounts):
+            amounts[userId] = amounts[userId, default: 0] > 0 ? 0 : nil
+            if amounts[userId] == nil { amounts.removeValue(forKey: userId) }
+            configuration.mode = .custom(amounts: amounts)
+        }
+    }
+
+    func setCustomAmount(_ cents: Int, for userId: Int) {
+        guard case .custom(var amounts) = configuration.mode else { return }
+        amounts[userId] = cents
+        configuration.mode = .custom(amounts: amounts)
+    }
+
+    func setPayer(_ userId: Int) {
+        configuration.payerId = userId
+    }
+
+    // MARK: - Saving
+
+    /// Returns the saved expense on success, nil on failure.
+    func save() async -> Expense? {
+        guard canSave else { return nil }
+
+        let trimmedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        let total = totalCents
+
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            if let expenseId = existingExpenseId {
+                return try await ExpenseService.shared.updateExpense(
+                    groupId: groupId,
+                    expenseId: expenseId,
+                    description: trimmedDescription,
+                    amount: Money.amount(cents: total),
+                    paidBy: configuration.payerId,
+                    date: date,
+                    splits: splits()
+                )
+            }
+
+            return try await ExpenseService.shared.createExpense(
+                groupId: groupId,
+                description: trimmedDescription,
+                amount: Money.amount(cents: total),
+                paidBy: configuration.payerId,
+                date: date,
+                splits: splits()
+            )
+        } catch {
+            errorMessage = Self.message(for: error)
+            return nil
+        }
+    }
+
+    /// The server's `400` is the client's message: it is the only thing that knows why a
+    /// split the client believes in was refused.
+    static func message(for error: Error) -> String {
+        guard case APIError.httpError(let status) = error else {
+            return error.localizedDescription
+        }
+        switch status {
+        case 400: return "The server rejected this expense. Check the amounts and try again."
+        case 403: return "You are not a member of this group."
+        case 404: return "This expense no longer exists."
+        default: return "Something went wrong (\(status)). Try again."
+        }
+    }
+}

--- a/Splitty/Splitty/ViewModels/GroupFormViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupFormViewModel.swift
@@ -63,7 +63,7 @@ class GroupFormViewModel: ObservableObject {
     }
     
     private static func message(for error: Error) -> String {
-        guard case APIError.httpError(let status) = error else {
+        guard case APIError.httpError(let status, _) = error else {
             return error.localizedDescription
         }
         switch status {

--- a/Splitty/Splitty/ViewModels/GroupViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupViewModel.swift
@@ -14,32 +14,68 @@ class GroupViewModel: ObservableObject {
     @Published var groupedExpenses: [GroupedExpense] = []
     @Published var isLoading = false
     @Published var errorMessage = ""
-    
-    // This should be set from the current user's ID from AuthService
-    private let currentUserId = 1 // TODO: Get from AuthService
-    
+
+    /// True while the balance worker still owes this group a recomputation, so the header
+    /// number is known to predate the last write.
+    @Published var balancesPending = false
+
+    var members: [GroupMember] { group?.members ?? [] }
+
     func loadGroupData(groupId: Int) async {
         isLoading = true
-        errorMessage = ""
         defer { isLoading = false }
-        
+        await load(groupId: groupId)
+    }
+
+    /// Reloads after a write without blanking the screen. Called **once**, on the sheet's
+    /// dismissal: `balancesPending` exists so a client can show a spinner instead of
+    /// polling, and the worker usually finishes inside the dismiss animation.
+    func refresh(groupId: Int) async {
+        await load(groupId: groupId)
+    }
+
+    private func load(groupId: Int) async {
+        errorMessage = ""
+
         async let groupResult = GroupService.shared.getGroup(id: groupId)
         async let expensesResult = ExpenseService.shared.getExpenses(groupId: groupId)
-        
-        // Both loads run to completion even if one fails; the later failure wins the
+        async let summaryResult = GroupService.shared.getBalanceSummary(groupId: groupId)
+
+        // Every load runs to completion even if one fails; the later failure wins the
         // single errorMessage slot.
         do {
             group = try await groupResult
         } catch {
             errorMessage = "Failed to load group: \(error.localizedDescription)"
         }
-        
+
         do {
             let loadedExpenses = try await expensesResult
             expenses = loadedExpenses
             groupedExpenses = Expense.groupExpensesByDate(loadedExpenses)
         } catch {
             errorMessage = "Failed to load expenses: \(error.localizedDescription)"
+        }
+
+        // A summary that fails to load is not worth an error line: the flag it carries only
+        // decides whether the header renders as provisional.
+        balancesPending = (try? await summaryResult)?.balancesPending ?? false
+    }
+
+    /// Deletes an expense or a settlement, whichever the row is. They do not share a route:
+    /// the expense route refuses payment rows rather than branching on a type the client
+    /// never sent.
+    func delete(_ expense: Expense, groupId: Int) async {
+        do {
+            switch expense.type {
+            case .expense:
+                try await ExpenseService.shared.deleteExpense(groupId: groupId, expenseId: expense.id)
+            case .payment:
+                try await SettlementService.shared.deleteSettlement(groupId: groupId, expenseId: expense.id)
+            }
+            await refresh(groupId: groupId)
+        } catch {
+            errorMessage = ExpenseFormViewModel.message(for: error)
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/GroupViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupViewModel.swift
@@ -15,6 +15,11 @@ class GroupViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage = ""
 
+    /// A failed delete belongs next to the list, not in place of it: `errorMessage` blanks
+    /// the timeline, which is the right shape for a load that failed and the wrong one for
+    /// an action that did.
+    @Published var actionErrorMessage: String?
+
     /// True while the balance worker still owes this group a recomputation, so the header
     /// number is known to predate the last write.
     @Published var balancesPending = false
@@ -32,6 +37,15 @@ class GroupViewModel: ObservableObject {
     /// polling, and the worker usually finishes inside the dismiss animation.
     func refresh(groupId: Int) async {
         await load(groupId: groupId)
+    }
+
+    /// Shows a just-saved expense without waiting for the refetch. The row is real — the
+    /// server returned it — while the *balance* it feeds is not, which is what
+    /// `balancesPending` says.
+    func insert(_ expense: Expense) {
+        expenses.removeAll { $0.id == expense.id }
+        expenses.append(expense)
+        groupedExpenses = Expense.groupExpensesByDate(expenses)
     }
 
     private func load(groupId: Int) async {
@@ -66,6 +80,8 @@ class GroupViewModel: ObservableObject {
     /// the expense route refuses payment rows rather than branching on a type the client
     /// never sent.
     func delete(_ expense: Expense, groupId: Int) async {
+        actionErrorMessage = nil
+
         do {
             switch expense.type {
             case .expense:
@@ -75,7 +91,7 @@ class GroupViewModel: ObservableObject {
             }
             await refresh(groupId: groupId)
         } catch {
-            errorMessage = ExpenseFormViewModel.message(for: error)
+            actionErrorMessage = error.displayMessage
         }
     }
 }

--- a/Splitty/Splitty/ViewModels/JoinGroupViewModel.swift
+++ b/Splitty/Splitty/ViewModels/JoinGroupViewModel.swift
@@ -45,7 +45,7 @@ class JoinGroupViewModel: ObservableObject {
     }
     
     private static func message(for error: Error) -> String {
-        guard case APIError.httpError(let status) = error else {
+        guard case APIError.httpError(let status, _) = error else {
             return error.localizedDescription
         }
         switch status {

--- a/Splitty/Splitty/Views/ExpenseDetailView.swift
+++ b/Splitty/Splitty/Views/ExpenseDetailView.swift
@@ -132,7 +132,7 @@ struct ExpenseDetailView: View {
                 onDeleted()
                 dismiss()
             } catch {
-                errorMessage = ExpenseFormViewModel.message(for: error)
+                errorMessage = error.displayMessage
             }
         }
     }

--- a/Splitty/Splitty/Views/ExpenseDetailView.swift
+++ b/Splitty/Splitty/Views/ExpenseDetailView.swift
@@ -1,0 +1,139 @@
+//
+//  ExpenseDetailView.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// A read-only view of one expense: the total, who paid, and every split. Editing reopens
+/// the same sheet that created it.
+struct ExpenseDetailView: View {
+    let expense: Expense
+    let members: [GroupMember]
+    let currentUserId: Int
+    let onChanged: () -> Void
+    let onDeleted: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingEditSheet = false
+    @State private var showingDeleteConfirmation = false
+    @State private var isDeleting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(expense.description)
+                        .font(.title2.weight(.semibold))
+                    Text(Money.formatted(amount: expense.amount))
+                        .font(.largeTitle.weight(.bold))
+                        .monospacedDigit()
+                    Text("\(payerName) paid · \(dateText)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("Split") {
+                ForEach(expense.splits) { split in
+                    HStack {
+                        Text(name(for: split.userId))
+                        Spacer()
+                        Text(Money.formatted(amount: split.amount))
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage).foregroundStyle(.red)
+                }
+            }
+
+        }
+        .navigationTitle("Expense")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if isDeleting {
+                    ProgressView()
+                } else {
+                    Button {
+                        showingDeleteConfirmation = true
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .accessibilityLabel("Delete expense")
+                }
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit") { showingEditSheet = true }
+                    .disabled(isDeleting)
+            }
+        }
+        .sheet(isPresented: $showingEditSheet) {
+            ExpenseSheet(
+                groupId: expense.groupId,
+                members: members,
+                currentUserId: currentUserId,
+                expense: expense
+            ) { _ in
+                onChanged()
+                dismiss()
+            }
+        }
+        // Every member may delete anything, so the confirmation names what is going, not
+        // who recorded it.
+        .confirmationDialog(
+            "Delete \"\(expense.description)\"?",
+            isPresented: $showingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { delete() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the expense and everyone's share of it.")
+        }
+    }
+
+    private var payerName: String {
+        expense.paidBy == currentUserId ? "You" : expense.paidByUser.name
+    }
+
+    private var dateText: String {
+        guard let date = expense.effectiveDate else { return "Unknown date" }
+        return date.formatted(.dateTime.weekday(.abbreviated).day().month().year())
+    }
+
+    private func name(for userId: Int) -> String {
+        userId == currentUserId
+            ? "You"
+            : members.first { $0.userId == userId }?.name
+                ?? expense.splits.first { $0.userId == userId }?.user.name
+                ?? "Unknown"
+    }
+
+    private func delete() {
+        isDeleting = true
+        errorMessage = nil
+
+        Task {
+            defer { isDeleting = false }
+            do {
+                try await ExpenseService.shared.deleteExpense(
+                    groupId: expense.groupId,
+                    expenseId: expense.id
+                )
+                onDeleted()
+                dismiss()
+            } catch {
+                errorMessage = ExpenseFormViewModel.message(for: error)
+            }
+        }
+    }
+}

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -64,7 +64,7 @@ struct ExpenseSheet: View {
 
                     // Held open whether the pad is showing its digits or not, so opening
                     // the keyboard moves nothing above it.
-                    Color.clear.frame(height: Self.padHeight)
+                    Color.clear.frame(height: bottomReserve)
                 }
                 // The content above the pad is anchored to the sheet, not to the keyboard:
                 // letting the system lift it as well produced two shifts at once.
@@ -218,8 +218,18 @@ struct ExpenseSheet: View {
     /// One action row and four digit rows, plus the padding under them. Reserved in the
     /// layout at all times: the pad shrinks to the action row when the keyboard takes over,
     /// and nothing above it is allowed to notice.
+    private static let actionRowHeight: CGFloat = 60
     private static let digitsHeight: CGFloat = 4 * 68 + 2 * 3
-    private static let padHeight: CGFloat = 60 + digitsHeight + 8
+    private static let padHeight: CGFloat = actionRowHeight + digitsHeight + 8
+
+    /// What the rows above have to keep clear. The pad's own height while the pad is up;
+    /// while the keyboard is up it is the keyboard plus the action row riding on it, which
+    /// is taller — so the description and the split move up towards the amount rather than
+    /// letting the arrow land on top of them.
+    private var bottomReserve: CGFloat {
+        guard descriptionFocused else { return Self.padHeight }
+        return keyboardInset + Self.actionRowHeight + 24
+    }
 
     /// The keyboard covers the digit grid, which is hidden under it anyway, so only the
     /// part of it that reaches past the grid moves the pad. Ignored unless the description

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -62,24 +62,13 @@ struct ExpenseSheet: View {
             .padding(.horizontal, 20)
             .padding(.top, 12)
             .padding(.bottom, 12)
-            .frame(maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            // The same colour the pad paints itself, so the two meet without a seam.
+            .background(Color(.systemBackground))
             .navigationTitle(viewModel.title)
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel") { dismiss() }
-                }
-
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if viewModel.isSaving {
-                        ProgressView()
-                    } else {
-                        Button("Save", action: save)
-                            .disabled(!saveable)
-                    }
-                }
-            }
             .presentationCornerRadius(28)
+            .presentationBackground(Color(.systemBackground))
             .task {
                 amountFocused = true
                 pasteableCents = await ClipboardPrice.detect()
@@ -98,8 +87,8 @@ struct ExpenseSheet: View {
             .onTapGesture { amountFocused = true }
             .background(alignment: .center) {
                 AmountInputField(
-                    pendingOperator: pendingOperator,
                     pasteableCents: pasteableCents,
+                    isNextEnabled: isNextEnabled,
                     isFocused: $amountFocused,
                     onKey: handle(key:)
                 )
@@ -121,7 +110,10 @@ struct ExpenseSheet: View {
                     text: $viewModel.description,
                     date: $viewModel.date,
                     isFocused: $descriptionFocused,
-                    placeholder: "What was it for?"
+                    placeholder: "What was it for?",
+                    isSubmitEnabled: viewModel.canSave,
+                    isSaving: viewModel.isSaving,
+                    onSubmit: save
                 )
                 .frame(height: 30)
 
@@ -154,22 +146,15 @@ struct ExpenseSheet: View {
 
     // MARK: - Behaviour
 
-    private var pendingOperator: CalculatorOperator? {
-        viewModel.amount.hasPendingExpression ? viewModel.amount.pendingOperator : nil
-    }
-
-    /// Save is available on the resolved value of the expression, pending operation and
-    /// all: refusing to save a number the app can compute is a puzzle, not a safeguard.
-    private var saveable: Bool { viewModel.canSave }
+    /// The pad's arrow only has to get you off the amount, so it lights up as soon as
+    /// there is one. Saving is gated on the sheet as a whole, from the description's bar.
+    private var isNextEnabled: Bool { viewModel.totalCents > 0 }
 
     private func handle(key: KeypadKey) {
         switch key {
         case .digit(let digit): viewModel.amount.type(digit: digit)
         case .decimalPoint: viewModel.amount.typeDecimalPoint()
         case .backspace: viewModel.amount.backspace()
-        case .clear: viewModel.amount.clear()
-        case .operation(let operation): viewModel.amount.apply(operation)
-        case .equals: viewModel.amount.evaluate()
         case .pasteAmount(let cents): viewModel.amount.replaceEntry(cents: cents)
         case .next:
             // Only the destination is set: making the description first responder resigns
@@ -179,8 +164,7 @@ struct ExpenseSheet: View {
     }
 
     private func save() {
-        // Auto-evaluate: a pending expression is an amount the user typed, not an error.
-        viewModel.amount.evaluate()
+        guard viewModel.canSave else { return }
 
         Task {
             if let expense = await viewModel.save() {

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -35,43 +35,51 @@ struct ExpenseSheet: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                headerRow
+            ZStack(alignment: .bottom) {
+                VStack(spacing: 24) {
+                    headerRow
 
-                Spacer(minLength: 12)
+                    Spacer(minLength: 12)
 
-                amountRow
+                    amountRow
 
-                Spacer(minLength: 12)
+                    Spacer(minLength: 12)
 
-                descriptionRow
-                splitRow
+                    descriptionRow
+                    splitRow
 
-                if let message = viewModel.blockingMessage {
-                    Text(message)
-                        .font(.subheadline)
-                        .foregroundStyle(.orange)
+                    if let message = viewModel.blockingMessage {
+                        Text(message)
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
+                    }
+
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.center)
+                    }
+
+                    // Held open whether the pad is showing its digits or not, so opening
+                    // the keyboard moves nothing above it.
+                    Color.clear.frame(height: Self.padHeight)
                 }
-
-                if let errorMessage = viewModel.errorMessage {
-                    Text(errorMessage)
-                        .font(.subheadline)
-                        .foregroundStyle(.red)
-                        .multilineTextAlignment(.center)
-                }
-
-                Spacer(minLength: 8)
+                // The content above the pad is anchored to the sheet, not to the keyboard:
+                // letting the system lift it as well produced two shifts at once.
+                .ignoresSafeArea(.keyboard, edges: .bottom)
 
                 // The pad is content, not a keyboard. As a keyboard it dismissed on its
                 // own clock, sliding out from under a sheet that was still on screen;
-                // owned by the sheet it simply travels with it.
-                if !descriptionFocused {
-                    ExpenseKeypad(
-                        pasteableCents: pasteableCents,
-                        isNextEnabled: isNextEnabled,
-                        onKey: handle(key:)
-                    )
-                }
+                // owned by the sheet it simply travels with it. Its action row survives
+                // the system keyboard and rides above it, so the arrow stays put.
+                ExpenseKeypad(
+                    pasteableCents: pasteableCents,
+                    isNextEnabled: isNextEnabled,
+                    isSaving: viewModel.isSaving,
+                    showsDigits: !descriptionFocused,
+                    onKey: handle(key:)
+                )
             }
             .padding(.horizontal, 12)
             .padding(.top, 12)
@@ -95,11 +103,24 @@ struct ExpenseSheet: View {
 
     // MARK: - Rows
 
-    /// The date on the left, and — while the system keyboard is up and the pad's own arrow
-    /// is off screen — the save action on the right, so there is never a moment with no way
-    /// forward and never two arrows at once.
+    /// The date, and nothing else: the forward action stays with the pad at the bottom of
+    /// the sheet whether the pad or the keyboard is up.
     private var headerRow: some View {
         HStack {
+            dateButton
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+    }
+
+    @ViewBuilder
+    private var dateButton: some View {
+        if #available(iOS 26.0, *) {
+            Button(dateLabel) { showingDatePicker = true }
+                .buttonStyle(.glass)
+                .tint(Color.expenseForeground)
+                .accessibilityIdentifier("expense.date")
+        } else {
             Button {
                 showingDatePicker = true
             } label: {
@@ -112,20 +133,7 @@ struct ExpenseSheet: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("expense.date")
-
-            Spacer()
-
-            if descriptionFocused {
-                if viewModel.isSaving {
-                    ProgressView().frame(width: 40, height: 40)
-                } else {
-                    ForwardButton(isEnabled: viewModel.canSave, diameter: 40, action: save)
-                        .accessibilityLabel("save")
-                        .accessibilityIdentifier("expense.save")
-                }
-            }
         }
-        .padding(.horizontal, 8)
     }
 
     private var dateLabel: String {
@@ -187,9 +195,16 @@ struct ExpenseSheet: View {
 
     // MARK: - Behaviour
 
-    /// The pad's arrow only has to get you off the amount, so it lights up as soon as
-    /// there is one. Saving is gated on the sheet as a whole, from the description's bar.
-    private var isNextEnabled: Bool { viewModel.totalCents > 0 }
+    /// One action row and four digit rows, plus the padding under them. Reserved in the
+    /// layout at all times: the pad shrinks to the action row when the keyboard takes over,
+    /// and nothing above it is allowed to notice.
+    private static let padHeight: CGFloat = 60 + 4 * 68 + 8
+
+    /// One arrow, two jobs: leaving the amount only needs an amount, but once the
+    /// description has focus the arrow is the save and answers to the whole sheet.
+    private var isNextEnabled: Bool {
+        descriptionFocused ? viewModel.canSave : viewModel.totalCents > 0
+    }
 
     private func handle(key: KeypadKey) {
         switch key {
@@ -198,9 +213,11 @@ struct ExpenseSheet: View {
         case .backspace: viewModel.amount.backspace()
         case .pasteAmount(let cents): viewModel.amount.replaceEntry(cents: cents)
         case .next:
-            // Only the destination is set: making the description first responder resigns
-            // the amount by itself, and resigning both in one pass races the handoff.
-            descriptionFocused = true
+            if descriptionFocused {
+                save()
+            } else {
+                descriptionFocused = true
+            }
         }
     }
 

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -80,7 +80,7 @@ struct ExpenseSheet: View {
                     showsDigits: !descriptionFocused,
                     onKey: handle(key:)
                 )
-                .padding(.bottom, keyboardInset)
+                .padding(.bottom, padBottomInset)
             }
             .padding(.horizontal, 12)
             .padding(.top, 12)
@@ -218,7 +218,17 @@ struct ExpenseSheet: View {
     /// One action row and four digit rows, plus the padding under them. Reserved in the
     /// layout at all times: the pad shrinks to the action row when the keyboard takes over,
     /// and nothing above it is allowed to notice.
-    private static let padHeight: CGFloat = 60 + 4 * 68 + 8
+    private static let digitsHeight: CGFloat = 4 * 68 + 2 * 3
+    private static let padHeight: CGFloat = 60 + digitsHeight + 8
+
+    /// The keyboard covers the digit grid, which is hidden under it anyway, so only the
+    /// part of it that reaches past the grid moves the pad. Ignored unless the description
+    /// is what the keyboard belongs to: the split screen raises one of its own, and acting
+    /// on that left the pad hoisted over the sheet on the way back.
+    private var padBottomInset: CGFloat {
+        guard descriptionFocused else { return 0 }
+        return max(0, keyboardInset - Self.digitsHeight)
+    }
 
     /// How far the keyboard reaches into the sheet, past the home indicator the sheet
     /// already clears.

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -5,14 +5,13 @@
 
 import SwiftUI
 
-/// Creates or edits an expense. The sheet opens on the amount, with the calculator pad up;
-/// everything else is one row below it.
+/// Creates or edits an expense. The sheet opens on the amount, with the pad up; everything
+/// else is one row below it.
 struct ExpenseSheet: View {
     @StateObject private var viewModel: ExpenseFormViewModel
     @Environment(\.dismiss) private var dismiss
 
-    @State private var amountFocused = false
-    @State private var descriptionFocused = false
+    @FocusState private var descriptionFocused: Bool
     @State private var pasteableCents: Int?
 
     private let onSaved: (Expense) -> Void
@@ -58,6 +57,18 @@ struct ExpenseSheet: View {
                         .multilineTextAlignment(.center)
                 }
 
+                Spacer(minLength: 8)
+
+                // The pad is content, not a keyboard. As a keyboard it dismissed on its
+                // own clock, sliding out from under a sheet that was still on screen;
+                // owned by the sheet it simply travels with it.
+                if !descriptionFocused {
+                    ExpenseKeypad(
+                        pasteableCents: pasteableCents,
+                        isNextEnabled: isNextEnabled,
+                        onKey: handle(key:)
+                    )
+                }
             }
             .padding(.horizontal, 20)
             .padding(.top, 12)
@@ -70,7 +81,6 @@ struct ExpenseSheet: View {
             .presentationCornerRadius(28)
             .presentationBackground(Color.expenseBackground)
             .task {
-                amountFocused = true
                 pasteableCents = await ClipboardPrice.detect()
             }
         }
@@ -78,23 +88,13 @@ struct ExpenseSheet: View {
 
     // MARK: - Rows
 
-    /// The number is drawn by `AmountDisplay`; the field underneath it is an invisible
-    /// responder that owns the pad. Tapping anywhere on the number focuses it.
+    /// Tapping the number puts the pad back, whichever field had focus.
     private var amountRow: some View {
         AmountDisplay(text: viewModel.amount.displayText)
             .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
-            .onTapGesture { amountFocused = true }
-            .background(alignment: .center) {
-                AmountInputField(
-                    pasteableCents: pasteableCents,
-                    isNextEnabled: isNextEnabled,
-                    isFocused: $amountFocused,
-                    onKey: handle(key:)
-                )
-                .frame(width: 1, height: 1)
-                .allowsHitTesting(false)
-            }
+            .onTapGesture { descriptionFocused = false }
+            .accessibilityIdentifier("expense.amount")
     }
 
     private var descriptionRow: some View {
@@ -106,16 +106,22 @@ struct ExpenseSheet: View {
                 .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
 
             VStack(alignment: .leading, spacing: 2) {
-                DescriptionInputField(
-                    text: $viewModel.description,
-                    date: $viewModel.date,
-                    isFocused: $descriptionFocused,
-                    placeholder: "What was it for?",
-                    isSubmitEnabled: viewModel.canSave,
-                    isSaving: viewModel.isSaving,
-                    onSubmit: save
-                )
-                .frame(height: 30)
+                TextField("What was it for?", text: $viewModel.description)
+                    .focused($descriptionFocused)
+                    .submitLabel(.done)
+                    .foregroundStyle(Color.expenseForeground)
+                    .accessibilityIdentifier("expense.description")
+                    .frame(height: 30)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            ExpenseDateAccessory(
+                                date: $viewModel.date,
+                                isSubmitEnabled: viewModel.canSave,
+                                isSaving: viewModel.isSaving,
+                                onSubmit: save
+                            )
+                        }
+                    }
 
                 Text(viewModel.date, format: .dateTime.weekday(.abbreviated).day().month().year())
                     .font(.caption)

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -64,11 +64,11 @@ struct ExpenseSheet: View {
             .padding(.bottom, 12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             // The same colour the pad paints itself, so the two meet without a seam.
-            .background(Color(.systemBackground))
+            .background(Color.expenseBackground)
             .navigationTitle(viewModel.title)
             .navigationBarTitleDisplayMode(.inline)
             .presentationCornerRadius(28)
-            .presentationBackground(Color(.systemBackground))
+            .presentationBackground(Color.expenseBackground)
             .task {
                 amountFocused = true
                 pasteableCents = await ClipboardPrice.detect()
@@ -103,7 +103,7 @@ struct ExpenseSheet: View {
                 .font(.system(size: 18))
                 .foregroundStyle(.secondary)
                 .frame(width: 48, height: 48)
-                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+                .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
 
             VStack(alignment: .leading, spacing: 2) {
                 DescriptionInputField(
@@ -131,7 +131,7 @@ struct ExpenseSheet: View {
             HStack {
                 Text(viewModel.splitSummary)
                     .font(.subheadline)
-                    .foregroundStyle(Color.primary)
+                    .foregroundStyle(Color.expenseForeground)
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(.caption)
@@ -139,7 +139,7 @@ struct ExpenseSheet: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
-            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+            .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
         }
         .accessibilityIdentifier("expense.split")
     }

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -1,0 +1,186 @@
+//
+//  ExpenseSheet.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// Creates or edits an expense. The sheet opens on the amount, with the calculator pad up;
+/// everything else is one row below it.
+struct ExpenseSheet: View {
+    @StateObject private var viewModel: ExpenseFormViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var amountFocused = false
+    @State private var descriptionFocused = false
+    @State private var pasteableCents: Int?
+
+    private let onSaved: (Expense) -> Void
+
+    init(
+        groupId: Int,
+        members: [GroupMember],
+        currentUserId: Int,
+        expense: Expense? = nil,
+        onSaved: @escaping (Expense) -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: ExpenseFormViewModel(
+            groupId: groupId,
+            members: members,
+            currentUserId: currentUserId,
+            expense: expense
+        ))
+        self.onSaved = onSaved
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                amountRow
+                descriptionRow
+                splitRow
+
+                if let message = viewModel.blockingMessage {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .navigationTitle(viewModel.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save", action: save)
+                            .disabled(!saveable)
+                    }
+                }
+            }
+            .task {
+                amountFocused = true
+                pasteableCents = await ClipboardPrice.detect()
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    private var amountRow: some View {
+        HStack(spacing: 14) {
+            // Currency is a static glyph: there is no currency field and no conversion.
+            Text("$")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 48, height: 48)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+
+            AmountInputField(
+                text: viewModel.amount.displayText,
+                pendingOperator: pendingOperator,
+                pasteableCents: pasteableCents,
+                isFocused: $amountFocused,
+                onKey: handle(key:)
+            )
+            .frame(height: 52)
+        }
+    }
+
+    private var descriptionRow: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "text.alignleft")
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+                .frame(width: 48, height: 48)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 2) {
+                DescriptionInputField(
+                    text: $viewModel.description,
+                    date: $viewModel.date,
+                    isFocused: $descriptionFocused,
+                    placeholder: "What was it for?"
+                )
+                .frame(height: 30)
+
+                Text(viewModel.date, format: .dateTime.weekday(.abbreviated).day().month().year())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var splitRow: some View {
+        NavigationLink {
+            SplitConfigurationView(viewModel: viewModel)
+        } label: {
+            HStack {
+                Text(viewModel.splitSummary)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .accessibilityIdentifier("expense.split")
+    }
+
+    // MARK: - Behaviour
+
+    private var pendingOperator: CalculatorOperator? {
+        viewModel.amount.hasPendingExpression ? viewModel.amount.pendingOperator : nil
+    }
+
+    /// Save is available on the resolved value of the expression, pending operation and
+    /// all: refusing to save a number the app can compute is a puzzle, not a safeguard.
+    private var saveable: Bool { viewModel.canSave }
+
+    private func handle(key: KeypadKey) {
+        switch key {
+        case .digit(let digit): viewModel.amount.type(digit: digit)
+        case .decimalPoint: viewModel.amount.typeDecimalPoint()
+        case .backspace: viewModel.amount.backspace()
+        case .clear: viewModel.amount.clear()
+        case .operation(let operation): viewModel.amount.apply(operation)
+        case .equals: viewModel.amount.evaluate()
+        case .pasteAmount(let cents): viewModel.amount.replaceEntry(cents: cents)
+        case .next:
+            // Only the destination is set: making the description first responder resigns
+            // the amount by itself, and resigning both in one pass races the handoff.
+            descriptionFocused = true
+        }
+    }
+
+    private func save() {
+        // Auto-evaluate: a pending expression is an amount the user typed, not an error.
+        viewModel.amount.evaluate()
+
+        Task {
+            if let expense = await viewModel.save() {
+                onSaved(expense)
+                dismiss()
+            }
+        }
+    }
+}

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -13,6 +13,7 @@ struct ExpenseSheet: View {
 
     @FocusState private var descriptionFocused: Bool
     @State private var pasteableCents: Int?
+    @State private var showingDatePicker = false
 
     private let onSaved: (Expense) -> Void
 
@@ -35,6 +36,8 @@ struct ExpenseSheet: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
+                headerRow
+
                 Spacer(minLength: 12)
 
                 amountRow
@@ -70,23 +73,67 @@ struct ExpenseSheet: View {
                     )
                 }
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 12)
             .padding(.top, 12)
             .padding(.bottom, 12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             // The same colour the pad paints itself, so the two meet without a seam.
             .background(Color.expenseBackground)
-            .navigationTitle(viewModel.title)
-            .navigationBarTitleDisplayMode(.inline)
+            // No bar: the sheet's own header carries what it needs, and an empty bar over
+            // the amount was only there to hold buttons that are gone.
+            .toolbar(.hidden, for: .navigationBar)
             .presentationCornerRadius(28)
             .presentationBackground(Color.expenseBackground)
             .task {
                 pasteableCents = await ClipboardPrice.detect()
             }
+            .sheet(isPresented: $showingDatePicker) {
+                ExpenseDatePicker(date: $viewModel.date)
+            }
         }
     }
 
     // MARK: - Rows
+
+    /// The date on the left, and — while the system keyboard is up and the pad's own arrow
+    /// is off screen — the save action on the right, so there is never a moment with no way
+    /// forward and never two arrows at once.
+    private var headerRow: some View {
+        HStack {
+            Button {
+                showingDatePicker = true
+            } label: {
+                Text(dateLabel)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Color.expenseForeground)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.expenseForeground.opacity(0.07), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("expense.date")
+
+            Spacer()
+
+            if descriptionFocused {
+                if viewModel.isSaving {
+                    ProgressView().frame(width: 40, height: 40)
+                } else {
+                    ForwardButton(isEnabled: viewModel.canSave, diameter: 40, action: save)
+                        .accessibilityLabel("save")
+                        .accessibilityIdentifier("expense.save")
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var dateLabel: String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(viewModel.date) { return "Today" }
+        if calendar.isDateInYesterday(viewModel.date) { return "Yesterday" }
+        return viewModel.date.formatted(.dateTime.day().month(.abbreviated).year())
+    }
 
     /// Tapping the number puts the pad back, whichever field had focus.
     private var amountRow: some View {
@@ -112,22 +159,9 @@ struct ExpenseSheet: View {
                     .foregroundStyle(Color.expenseForeground)
                     .accessibilityIdentifier("expense.description")
                     .frame(height: 30)
-                    .toolbar {
-                        ToolbarItemGroup(placement: .keyboard) {
-                            ExpenseDateAccessory(
-                                date: $viewModel.date,
-                                isSubmitEnabled: viewModel.canSave,
-                                isSaving: viewModel.isSaving,
-                                onSubmit: save
-                            )
-                        }
-                    }
-
-                Text(viewModel.date, format: .dateTime.weekday(.abbreviated).day().month().year())
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
+        .padding(.horizontal, 8)
     }
 
     private var splitRow: some View {
@@ -146,6 +180,7 @@ struct ExpenseSheet: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
             .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
         }
         .accessibilityIdentifier("expense.split")
     }

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -36,7 +36,12 @@ struct ExpenseSheet: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
+                Spacer(minLength: 12)
+
                 amountRow
+
+                Spacer(minLength: 12)
+
                 descriptionRow
                 splitRow
 
@@ -53,10 +58,11 @@ struct ExpenseSheet: View {
                         .multilineTextAlignment(.center)
                 }
 
-                Spacer()
             }
             .padding(.horizontal, 20)
-            .padding(.top, 24)
+            .padding(.top, 12)
+            .padding(.bottom, 12)
+            .frame(maxHeight: .infinity, alignment: .top)
             .navigationTitle(viewModel.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -73,6 +79,7 @@ struct ExpenseSheet: View {
                     }
                 }
             }
+            .presentationCornerRadius(28)
             .task {
                 amountFocused = true
                 pasteableCents = await ClipboardPrice.detect()
@@ -82,24 +89,23 @@ struct ExpenseSheet: View {
 
     // MARK: - Rows
 
+    /// The number is drawn by `AmountDisplay`; the field underneath it is an invisible
+    /// responder that owns the pad. Tapping anywhere on the number focuses it.
     private var amountRow: some View {
-        HStack(spacing: 14) {
-            // Currency is a static glyph: there is no currency field and no conversion.
-            Text("$")
-                .font(.system(size: 28, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 48, height: 48)
-                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
-
-            AmountInputField(
-                text: viewModel.amount.displayText,
-                pendingOperator: pendingOperator,
-                pasteableCents: pasteableCents,
-                isFocused: $amountFocused,
-                onKey: handle(key:)
-            )
-            .frame(height: 52)
-        }
+        AmountDisplay(text: viewModel.amount.displayText)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture { amountFocused = true }
+            .background(alignment: .center) {
+                AmountInputField(
+                    pendingOperator: pendingOperator,
+                    pasteableCents: pasteableCents,
+                    isFocused: $amountFocused,
+                    onKey: handle(key:)
+                )
+                .frame(width: 1, height: 1)
+                .allowsHitTesting(false)
+            }
     }
 
     private var descriptionRow: some View {

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 /// Creates or edits an expense. The sheet opens on the amount, with the pad up; everything
 /// else is one row below it.
@@ -12,8 +13,8 @@ struct ExpenseSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     @FocusState private var descriptionFocused: Bool
-    @State private var pasteableCents: Int?
     @State private var showingDatePicker = false
+    @State private var keyboardInset: CGFloat = 0
 
     private let onSaved: (Expense) -> Void
 
@@ -74,17 +75,21 @@ struct ExpenseSheet: View {
                 // owned by the sheet it simply travels with it. Its action row survives
                 // the system keyboard and rides above it, so the arrow stays put.
                 ExpenseKeypad(
-                    pasteableCents: pasteableCents,
                     isNextEnabled: isNextEnabled,
                     isSaving: viewModel.isSaving,
                     showsDigits: !descriptionFocused,
                     onKey: handle(key:)
                 )
+                .padding(.bottom, keyboardInset)
             }
             .padding(.horizontal, 12)
             .padding(.top, 12)
             .padding(.bottom, 12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            // The keyboard is answered by hand, below: letting SwiftUI lift the sheet moved
+            // the pad outside the bounds it is hit-tested against, so the arrow drew in the
+            // right place and answered to nothing.
+            .ignoresSafeArea(.keyboard, edges: .bottom)
             // The same colour the pad paints itself, so the two meet without a seam.
             .background(Color.expenseBackground)
             // No bar: the sheet's own header carries what it needs, and an empty bar over
@@ -92,8 +97,15 @@ struct ExpenseSheet: View {
             .toolbar(.hidden, for: .navigationBar)
             .presentationCornerRadius(28)
             .presentationBackground(Color.expenseBackground)
-            .task {
-                pasteableCents = await ClipboardPrice.detect()
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIResponder.keyboardWillChangeFrameNotification
+            )) { note in
+                setKeyboardInset(from: note)
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIResponder.keyboardWillHideNotification
+            )) { _ in
+                withAnimation(.easeOut(duration: 0.25)) { keyboardInset = 0 }
             }
             .sheet(isPresented: $showingDatePicker) {
                 ExpenseDatePicker(date: $viewModel.date)
@@ -116,10 +128,18 @@ struct ExpenseSheet: View {
     @ViewBuilder
     private var dateButton: some View {
         if #available(iOS 26.0, *) {
-            Button(dateLabel) { showingDatePicker = true }
-                .buttonStyle(.glass)
-                .tint(Color.expenseForeground)
-                .accessibilityIdentifier("expense.date")
+            Button {
+                showingDatePicker = true
+            } label: {
+                Text(dateLabel)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Color.expenseForeground)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .glassEffect(.regular, in: .capsule)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("expense.date")
         } else {
             Button {
                 showingDatePicker = true
@@ -200,6 +220,19 @@ struct ExpenseSheet: View {
     /// and nothing above it is allowed to notice.
     private static let padHeight: CGFloat = 60 + 4 * 68 + 8
 
+    /// How far the keyboard reaches into the sheet, past the home indicator the sheet
+    /// already clears.
+    private func setKeyboardInset(from note: Notification) {
+        guard let frame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let window = UIApplication.shared.connectedScenes
+                  .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
+                  .first
+        else { return }
+
+        let overlap = max(0, window.bounds.maxY - frame.minY - window.safeAreaInsets.bottom)
+        withAnimation(.easeOut(duration: 0.25)) { keyboardInset = overlap }
+    }
+
     /// One arrow, two jobs: leaving the amount only needs an amount, but once the
     /// description has focus the arrow is the save and answers to the whole sheet.
     private var isNextEnabled: Bool {
@@ -211,7 +244,6 @@ struct ExpenseSheet: View {
         case .digit(let digit): viewModel.amount.type(digit: digit)
         case .decimalPoint: viewModel.amount.typeDecimalPoint()
         case .backspace: viewModel.amount.backspace()
-        case .pasteAmount(let cents): viewModel.amount.replaceEntry(cents: cents)
         case .next:
             if descriptionFocused {
                 save()

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -10,11 +10,17 @@ import SwiftUI
 struct GroupView: View {
     let groupId: Int
     @StateObject private var viewModel = GroupViewModel()
+    @StateObject private var authManager = AuthenticationManager.shared
     @Environment(\.dismiss) private var dismiss
     @State private var showingEditSheet = false
-    
+    @State private var showingExpenseSheet = false
+    @State private var pendingDeletion: Expense?
+
+    /// The floating button clears the last row rather than covering it.
+    private let listBottomInset: CGFloat = 88
+
     var body: some View {
-        ZStack {
+        ZStack(alignment: .bottomTrailing) {
             Color("background")
                 .ignoresSafeArea()
             
@@ -22,19 +28,12 @@ struct GroupView: View {
                 ProgressView("Loading...")
                     .foregroundColor(Color("foreground"))
             } else {
-                ScrollView {
-                    VStack(spacing: 0) {
-                        // Header Section
-                        headerSection
-                        
-                        // Action Buttons
-                        actionButtonsSection
-                        
-                        // Expenses List
-                        expensesList
-                    }
-                }
+                content
             }
+
+            // The screen's primary action does not belong in a toolbar already carrying
+            // Back and Edit, and a floating button survives the list scrolling.
+            addExpenseButton
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
@@ -62,9 +61,156 @@ struct GroupView: View {
                 Task { await viewModel.loadGroupData(groupId: groupId) }
             }
         }
+        .sheet(isPresented: $showingExpenseSheet) {
+            if let currentUserId {
+                ExpenseSheet(
+                    groupId: groupId,
+                    members: viewModel.members,
+                    currentUserId: currentUserId
+                ) { _ in }
+            }
+        }
+        // A money write enqueues a recomputation, so the header balance is stale on return.
+        // One refetch, no polling: the flag it reads exists for exactly this.
+        .onChange(of: showingExpenseSheet) { _, isPresented in
+            if !isPresented {
+                Task { await viewModel.refresh(groupId: groupId) }
+            }
+        }
+        .confirmationDialog(
+            deletionTitle,
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let expense = pendingDeletion {
+                    pendingDeletion = nil
+                    Task { await viewModel.delete(expense, groupId: groupId) }
+                }
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        }
         .task {
             await viewModel.loadGroupData(groupId: groupId)
         }
+    }
+
+    private var currentUserId: Int? { authManager.currentUser?.id }
+
+    private var content: some View {
+        List {
+            Section {
+                VStack(spacing: 0) {
+                    headerSection
+                    actionButtonsSection
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color("background"))
+                .listRowSeparator(.hidden)
+            }
+
+            if !viewModel.errorMessage.isEmpty {
+                Section {
+                    Text("Error: \(viewModel.errorMessage)")
+                        .foregroundColor(.red)
+                        .listRowBackground(Color("card"))
+                }
+            } else if viewModel.expenses.isEmpty {
+                Section {
+                    Text("No expenses yet. Add the first one.")
+                        .foregroundColor(Color("muted-foreground"))
+                        .listRowBackground(Color("card"))
+                        .listRowSeparator(.hidden)
+                }
+            } else {
+                ForEach(viewModel.groupedExpenses, id: \.dateString) { groupedExpense in
+                    Section {
+                        ForEach(groupedExpense.expenses) { expense in
+                            expenseRow(expense)
+                        }
+                    } header: {
+                        dateHeader(for: groupedExpense)
+                    }
+                }
+            }
+
+            Color.clear
+                .frame(height: listBottomInset)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color("card"))
+                .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Color("background"))
+    }
+
+    @ViewBuilder
+    private func expenseRow(_ expense: Expense) -> some View {
+        NavigationLink {
+            if let currentUserId {
+                switch expense.type {
+                case .expense:
+                    ExpenseDetailView(
+                        expense: expense,
+                        members: viewModel.members,
+                        currentUserId: currentUserId,
+                        onChanged: { Task { await viewModel.refresh(groupId: groupId) } },
+                        onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
+                    )
+                case .payment:
+                    SettlementDetailView(
+                        settlement: expense,
+                        members: viewModel.members,
+                        currentUserId: currentUserId,
+                        onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
+                    )
+                }
+            }
+        } label: {
+            ExpenseRow(expense: expense, currentUserId: currentUserId ?? 0)
+        }
+        .listRowInsets(EdgeInsets())
+        .listRowBackground(Color("card"))
+        .listRowSeparator(.hidden)
+        // Any member may delete anything, including a settlement someone else recorded —
+        // membership is the only authorization boundary in the system.
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                pendingDeletion = expense
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    private var deletionTitle: String {
+        guard let expense = pendingDeletion else { return "Delete?" }
+        return expense.type == .payment
+            ? "Delete the \(Money.formatted(amount: expense.amount)) payment?"
+            : "Delete \"\(expense.description)\"?"
+    }
+
+    private var addExpenseButton: some View {
+        Button {
+            showingExpenseSheet = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundColor(Color("background"))
+                .frame(width: 56, height: 56)
+                .background(Color("foreground"))
+                .clipShape(Circle())
+                .shadow(radius: 8, y: 4)
+        }
+        .padding(.trailing, 20)
+        .padding(.bottom, 24)
+        .disabled(currentUserId == nil || viewModel.group == nil)
+        .accessibilityIdentifier("group.addExpense")
+        .accessibilityLabel("Add expense")
     }
     
     private var headerSection: some View {
@@ -95,15 +241,25 @@ struct GroupView: View {
     @ViewBuilder
     private var balanceText: some View {
         if let balance = viewModel.group?.netBalance {
-            if balance > 0 {
-                Text("You are owed $\(String(format: "%.2f", balance)) overall")
-                    .foregroundColor(Color("muted-foreground"))
-            } else if balance < 0 {
-                Text("You owe $\(String(format: "%.2f", abs(balance))) overall")
-                    .foregroundColor(Color("muted-foreground"))
-            } else {
-                Text("You are all settled up")
-                    .foregroundColor(Color("muted-foreground"))
+            HStack(spacing: 6) {
+                SwiftUI.Group {
+                    if balance > 0 {
+                        Text("You are owed \(Money.formatted(amount: balance)) overall")
+                    } else if balance < 0 {
+                        Text("You owe \(Money.formatted(amount: abs(balance))) overall")
+                    } else {
+                        Text("You are all settled up")
+                    }
+                }
+                // A recomputation is outstanding, so this number predates the last write.
+                // Greyed with a spinner rather than presented as final.
+                .foregroundColor(Color("muted-foreground"))
+                .opacity(viewModel.balancesPending ? 0.5 : 1)
+
+                if viewModel.balancesPending {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
             }
         } else {
             Text("Loading balance...")
@@ -133,37 +289,6 @@ struct GroupView: View {
         .padding(.vertical, 20)
     }
     
-    private var expensesList: some View {
-        VStack {
-            if !viewModel.errorMessage.isEmpty {
-                Text("Error: \(viewModel.errorMessage)")
-                    .foregroundColor(.red)
-                    .padding()
-            } else if viewModel.expenses.isEmpty {
-                Text("No expenses found (\(viewModel.expenses.count) total, \(viewModel.groupedExpenses.count) grouped)")
-                    .foregroundColor(Color("muted-foreground"))
-                    .padding()
-            } else {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.groupedExpenses, id: \.dateString) { groupedExpense in
-                        VStack(spacing: 0) {
-                            // Date header
-                            dateHeader(for: groupedExpense)
-                            
-                            // Expenses for this date
-                            ForEach(groupedExpense.expenses) { expense in
-                                ExpenseRow(expense: expense)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .background(Color("card"))
-        .cornerRadius(20, corners: [.topLeft, .topRight])
-        .padding(.top, 0)
-    }
-    
     private func dateHeader(for groupedExpense: GroupedExpense) -> some View {
         HStack {
             Text(groupedExpense.dateString)
@@ -172,18 +297,11 @@ struct GroupView: View {
                 .foregroundColor(Color("card-foreground"))
             
             Spacer()
-            
-            Text("Latest")
-                .font(.subheadline)
-                .foregroundColor(Color("muted-foreground"))
-            
-            Image(systemName: "chevron.down")
-                .font(.caption)
-                .foregroundColor(Color("muted-foreground"))
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
         .background(Color("card"))
+        .listRowInsets(EdgeInsets())
     }
 }
 
@@ -203,12 +321,13 @@ struct ActionButton: View {
                 .background(color)
                 .cornerRadius(20)
         }
+        .buttonStyle(.plain)
     }
 }
 
 struct ExpenseRow: View {
     let expense: Expense
-    private let currentUserId = 4 // TODO: Get from AuthService
+    let currentUserId: Int
     
     var body: some View {
         HStack(spacing: 16) {
@@ -263,30 +382,66 @@ struct ExpenseRow: View {
     private var categoryIconName: String {
         switch expense.type {
         case .expense: return "dollarsign.circle.fill"
-        case .payment: return "arrow.down.circle.fill"
+        case .payment: return "arrow.left.arrow.right"
         }
+    }
+
+    private var isUserPaid: Bool { expense.paidBy == currentUserId }
+
+    /// A settlement's splits are `[+amount, -amount]`, so the counterparty is the split
+    /// that is not the payer's.
+    private var peerName: String {
+        expense.splits.first { $0.userId != expense.paidBy }?.user.name ?? "someone"
     }
     
     private var paymentText: some View {
-        let displayInfo = expense.getDisplayInfo(currentUserId: currentUserId)
-        return Text(displayInfo.isUserPaid ? "You paid $\(String(format: "%.2f", expense.amount))" : "\(expense.paidByUser.name) paid $\(String(format: "%.2f", expense.amount))")
-            .font(.subheadline)
-            .foregroundColor(Color("muted-foreground"))
+        SwiftUI.Group {
+            // Settlements live in the same timeline as expenses, in their own row style
+            // rather than a separate feed.
+            if expense.type == .payment {
+                Text(isUserPaid ? "You paid \(peerName)" : "\(expense.paidByUser.name) paid \(payeeLabel)")
+            } else {
+                Text(isUserPaid
+                     ? "You paid \(Money.formatted(amount: expense.amount))"
+                     : "\(expense.paidByUser.name) paid \(Money.formatted(amount: expense.amount))")
+            }
+        }
+        .font(.subheadline)
+        .foregroundColor(Color("muted-foreground"))
+    }
+
+    private var payeeLabel: String {
+        let peerId = expense.splits.first { $0.userId != expense.paidBy }?.userId
+        return peerId == currentUserId ? "you" : peerName
     }
     
+    @ViewBuilder
     private var balanceLabel: some View {
-        let displayInfo = expense.getDisplayInfo(currentUserId: currentUserId)
-        return Text(displayInfo.isUserPaid ? "you lent" : "you borrowed")
-            .font(.caption)
-            .foregroundColor(displayInfo.isUserPaid ? Color.green : Color.red)
+        if expense.type == .payment {
+            Text("payment")
+                .font(.caption)
+                .foregroundColor(Color("muted-foreground"))
+        } else {
+            Text(isUserPaid ? "you lent" : "you borrowed")
+                .font(.caption)
+                .foregroundColor(isUserPaid ? Color.green : Color.red)
+        }
     }
     
+    @ViewBuilder
     private var balanceAmount: some View {
-        let displayInfo = expense.getDisplayInfo(currentUserId: currentUserId)
-        return Text("$\(String(format: "%.2f", abs(displayInfo.userSplit)))")
-            .font(.headline)
-            .fontWeight(.semibold)
-            .foregroundColor(displayInfo.isUserPaid ? Color.green : Color.red)
+        if expense.type == .payment {
+            Text(Money.formatted(amount: expense.amount))
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundColor(Color("card-foreground"))
+        } else {
+            let share = expense.getDisplayInfo(currentUserId: currentUserId)
+            Text(Money.formatted(amount: isUserPaid ? expense.amount - share.userSplit : share.userSplit))
+                .font(.headline)
+                .fontWeight(.semibold)
+                .foregroundColor(isUserPaid ? Color.green : Color.red)
+        }
     }
 }
 

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -173,20 +173,17 @@ struct GroupView: View {
         }
     }
 
-    /// A button rather than a `NavigationLink`: a link in a list draws a disclosure
-    /// chevron, and these rows already say where they go. Any member may delete anything,
+    /// A tap rather than a `NavigationLink`: a link in a list draws a disclosure chevron,
+    /// and these rows already say where they go. Any member may delete anything,
     /// including a settlement someone else recorded — membership is the only authorization
     /// boundary in the system.
     private func expenseRow(_ expense: Expense, currentUserId: Int) -> some View {
         SwipeToDeleteRow {
+            selectedExpenseId = expense.id
+        } onDelete: {
             pendingDeletion = expense
         } content: {
-            Button {
-                selectedExpenseId = expense.id
-            } label: {
-                ExpenseRow(expense: expense, currentUserId: currentUserId)
-            }
-            .buttonStyle(.plain)
+            ExpenseRow(expense: expense, currentUserId: currentUserId)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color("card"))

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -80,21 +80,23 @@ struct GroupView: View {
                 Task { await viewModel.refresh(groupId: groupId) }
             }
         }
-        .confirmationDialog(
+        // An alert, not a confirmation dialog: deleting is destructive and irreversible,
+        // and the question is worth a modal that names what it is about.
+        .alert(
             deletionTitle,
             isPresented: Binding(
                 get: { pendingDeletion != nil },
                 set: { if !$0 { pendingDeletion = nil } }
             ),
-            titleVisibility: .visible
-        ) {
+            presenting: pendingDeletion
+        ) { expense in
             Button("Delete", role: .destructive) {
-                if let expense = pendingDeletion {
-                    pendingDeletion = nil
-                    Task { await viewModel.delete(expense, groupId: groupId) }
-                }
+                pendingDeletion = nil
+                Task { await viewModel.delete(expense, groupId: groupId) }
             }
             Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: { _ in
+            Text("This cannot be undone.")
         }
         .task {
             await viewModel.loadGroupData(groupId: groupId)

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -67,7 +67,9 @@ struct GroupView: View {
                     groupId: groupId,
                     members: viewModel.members,
                     currentUserId: currentUserId
-                ) { _ in }
+                ) { saved in
+                    viewModel.insert(saved)
+                }
             }
         }
         // A money write enqueues a recomputation, so the header balance is stale on return.
@@ -112,6 +114,14 @@ struct GroupView: View {
                 .listRowSeparator(.hidden)
             }
 
+            if let actionErrorMessage = viewModel.actionErrorMessage {
+                Section {
+                    Text(actionErrorMessage)
+                        .foregroundColor(.red)
+                        .listRowBackground(Color("card"))
+                }
+            }
+
             if !viewModel.errorMessage.isEmpty {
                 Section {
                     Text("Error: \(viewModel.errorMessage)")
@@ -150,8 +160,14 @@ struct GroupView: View {
 
     @ViewBuilder
     private func expenseRow(_ expense: Expense) -> some View {
+        if let currentUserId {
+            expenseRow(expense, currentUserId: currentUserId)
+        }
+    }
+
+    private func expenseRow(_ expense: Expense, currentUserId: Int) -> some View {
         NavigationLink {
-            if let currentUserId {
+            SwiftUI.Group {
                 switch expense.type {
                 case .expense:
                     ExpenseDetailView(
@@ -171,7 +187,7 @@ struct GroupView: View {
                 }
             }
         } label: {
-            ExpenseRow(expense: expense, currentUserId: currentUserId ?? 0)
+            ExpenseRow(expense: expense, currentUserId: currentUserId)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color("card"))
@@ -297,6 +313,14 @@ struct GroupView: View {
                 .foregroundColor(Color("card-foreground"))
             
             Spacer()
+            
+            Text("Latest")
+                .font(.subheadline)
+                .foregroundColor(Color("muted-foreground"))
+            
+            Image(systemName: "chevron.down")
+                .font(.caption)
+                .foregroundColor(Color("muted-foreground"))
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
@@ -388,10 +412,8 @@ struct ExpenseRow: View {
 
     private var isUserPaid: Bool { expense.paidBy == currentUserId }
 
-    /// A settlement's splits are `[+amount, -amount]`, so the counterparty is the split
-    /// that is not the payer's.
     private var peerName: String {
-        expense.splits.first { $0.userId != expense.paidBy }?.user.name ?? "someone"
+        expense.peer?.name ?? "someone"
     }
     
     private var paymentText: some View {
@@ -411,8 +433,7 @@ struct ExpenseRow: View {
     }
 
     private var payeeLabel: String {
-        let peerId = expense.splits.first { $0.userId != expense.paidBy }?.userId
-        return peerId == currentUserId ? "you" : peerName
+        expense.peer?.id == currentUserId ? "you" : peerName
     }
     
     @ViewBuilder
@@ -436,8 +457,9 @@ struct ExpenseRow: View {
                 .fontWeight(.semibold)
                 .foregroundColor(Color("card-foreground"))
         } else {
-            let share = expense.getDisplayInfo(currentUserId: currentUserId)
-            Text(Money.formatted(amount: isUserPaid ? expense.amount - share.userSplit : share.userSplit))
+            // Signed: what the payer lent is the total less their own share, and what
+            // anyone else borrowed is their share.
+            Text(Money.formatted(amount: abs(expense.getUserSplit(currentUserId: currentUserId))))
                 .font(.headline)
                 .fontWeight(.semibold)
                 .foregroundColor(isUserPaid ? Color.green : Color.red)

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -15,6 +15,7 @@ struct GroupView: View {
     @State private var showingEditSheet = false
     @State private var showingExpenseSheet = false
     @State private var pendingDeletion: Expense?
+    @State private var selectedExpenseId: Int?
 
     /// The floating button clears the last row rather than covering it.
     private let listBottomInset: CGFloat = 88
@@ -156,6 +157,11 @@ struct GroupView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(Color("background"))
+        .navigationDestination(item: $selectedExpenseId) { expenseId in
+            if let currentUserId {
+                detail(for: expenseId, currentUserId: currentUserId)
+            }
+        }
     }
 
     @ViewBuilder
@@ -165,40 +171,45 @@ struct GroupView: View {
         }
     }
 
+    /// A button rather than a `NavigationLink`: a link in a list draws a disclosure
+    /// chevron, and these rows already say where they go. Any member may delete anything,
+    /// including a settlement someone else recorded — membership is the only authorization
+    /// boundary in the system.
     private func expenseRow(_ expense: Expense, currentUserId: Int) -> some View {
-        NavigationLink {
-            SwiftUI.Group {
-                switch expense.type {
-                case .expense:
-                    ExpenseDetailView(
-                        expense: expense,
-                        members: viewModel.members,
-                        currentUserId: currentUserId,
-                        onChanged: { Task { await viewModel.refresh(groupId: groupId) } },
-                        onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
-                    )
-                case .payment:
-                    SettlementDetailView(
-                        settlement: expense,
-                        members: viewModel.members,
-                        currentUserId: currentUserId,
-                        onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
-                    )
-                }
+        SwipeToDeleteRow {
+            pendingDeletion = expense
+        } content: {
+            Button {
+                selectedExpenseId = expense.id
+            } label: {
+                ExpenseRow(expense: expense, currentUserId: currentUserId)
             }
-        } label: {
-            ExpenseRow(expense: expense, currentUserId: currentUserId)
+            .buttonStyle(.plain)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color("card"))
         .listRowSeparator(.hidden)
-        // Any member may delete anything, including a settlement someone else recorded —
-        // membership is the only authorization boundary in the system.
-        .swipeActions(edge: .trailing) {
-            Button(role: .destructive) {
-                pendingDeletion = expense
-            } label: {
-                Label("Delete", systemImage: "trash")
+    }
+
+    @ViewBuilder
+    private func detail(for expenseId: Int, currentUserId: Int) -> some View {
+        if let expense = viewModel.expenses.first(where: { $0.id == expenseId }) {
+            switch expense.type {
+            case .expense:
+                ExpenseDetailView(
+                    expense: expense,
+                    members: viewModel.members,
+                    currentUserId: currentUserId,
+                    onChanged: { Task { await viewModel.refresh(groupId: groupId) } },
+                    onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
+                )
+            case .payment:
+                SettlementDetailView(
+                    settlement: expense,
+                    members: viewModel.members,
+                    currentUserId: currentUserId,
+                    onDeleted: { Task { await viewModel.refresh(groupId: groupId) } }
+                )
             }
         }
     }

--- a/Splitty/Splitty/Views/LoginView.swift
+++ b/Splitty/Splitty/Views/LoginView.swift
@@ -145,7 +145,7 @@ struct LoginView: View {
 
         if let apiError = error as? APIError {
             switch apiError {
-            case .httpError(401):
+            case .httpError(401, _):
                 return "Google couldn't verify that account. Try again."
             case .httpError, .decodingError, .invalidResponse:
                 return "Something went wrong signing you in. Try again in a moment."

--- a/Splitty/Splitty/Views/LoginView.swift
+++ b/Splitty/Splitty/Views/LoginView.swift
@@ -124,7 +124,7 @@ struct LoginView: View {
         do {
             let user = try await AuthService.shared.signInWithGoogle()
             print("✅ Sign-in successful for user: \(user.name)")
-            authManager.login()
+            authManager.login(user: user)
         } catch GoogleSignInError.cancelled {
             // Dismissing the sheet is deliberate; nothing to report.
         } catch {
@@ -247,7 +247,7 @@ private struct DevSignInPicker: View {
         do {
             let user = try await AuthService.shared.devSignIn(email: email)
             print("✅ Dev sign-in successful for user: \(user.name)")
-            authManager.login()
+            authManager.login(user: user)
         } catch {
             errorMessage = LoginView.message(for: error)
         }

--- a/Splitty/Splitty/Views/SettlementDetailView.swift
+++ b/Splitty/Splitty/Views/SettlementDetailView.swift
@@ -1,0 +1,123 @@
+//
+//  SettlementDetailView.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// A read-only view of one settlement: who paid whom, and when.
+///
+/// Delete-only. Editing a settlement belongs to the screen that records them, which owns
+/// the cap on what a member may repay; building that form twice is not worth it.
+struct SettlementDetailView: View {
+    let settlement: Expense
+    let members: [GroupMember]
+    let currentUserId: Int
+    let onDeleted: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingDeleteConfirmation = false
+    @State private var isDeleting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(Money.formatted(amount: settlement.amount))
+                        .font(.largeTitle.weight(.bold))
+                        .monospacedDigit()
+                    Text("\(payerName) paid \(payeeName)")
+                        .font(.headline)
+                    Text(dateText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage).foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                // Invariant 2: membership is the only authorization boundary. A settlement
+                // someone else recorded is no more protected than an expense they logged.
+                Text("Any member can delete a settlement, including one someone else recorded.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Settlement")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if isDeleting {
+                    ProgressView()
+                } else {
+                    Button {
+                        showingDeleteConfirmation = true
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .accessibilityLabel("Delete settlement")
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete the \(Money.formatted(amount: settlement.amount)) payment from \(payerName) to \(payeeName)?",
+            isPresented: $showingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { delete() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The balance between them goes back to what it was before this payment.")
+        }
+    }
+
+    /// The counterparty is the split that is not the payer's — the shape every settlement
+    /// is built with.
+    private var peerId: Int? {
+        settlement.splits.first { $0.userId != settlement.paidBy }?.userId
+    }
+
+    private var payerName: String {
+        settlement.paidBy == currentUserId ? "You" : settlement.paidByUser.name
+    }
+
+    private var payeeName: String {
+        guard let peerId else { return "someone who has left" }
+        return peerId == currentUserId
+            ? "you"
+            : members.first { $0.userId == peerId }?.name
+                ?? settlement.splits.first { $0.userId == peerId }?.user.name
+                ?? "someone who has left"
+    }
+
+    private var dateText: String {
+        guard let date = settlement.effectiveDate else { return "Unknown date" }
+        return date.formatted(.dateTime.weekday(.abbreviated).day().month().year())
+    }
+
+    private func delete() {
+        isDeleting = true
+        errorMessage = nil
+
+        Task {
+            defer { isDeleting = false }
+            do {
+                try await SettlementService.shared.deleteSettlement(
+                    groupId: settlement.groupId,
+                    expenseId: settlement.id
+                )
+                onDeleted()
+                dismiss()
+            } catch {
+                errorMessage = ExpenseFormViewModel.message(for: error)
+            }
+        }
+    }
+}

--- a/Splitty/Splitty/Views/SettlementDetailView.swift
+++ b/Splitty/Splitty/Views/SettlementDetailView.swift
@@ -78,23 +78,15 @@ struct SettlementDetailView: View {
         }
     }
 
-    /// The counterparty is the split that is not the payer's — the shape every settlement
-    /// is built with.
-    private var peerId: Int? {
-        settlement.splits.first { $0.userId != settlement.paidBy }?.userId
-    }
-
     private var payerName: String {
         settlement.paidBy == currentUserId ? "You" : settlement.paidByUser.name
     }
 
     private var payeeName: String {
-        guard let peerId else { return "someone who has left" }
-        return peerId == currentUserId
+        guard let peer = settlement.peer else { return "someone who has left" }
+        return peer.id == currentUserId
             ? "you"
-            : members.first { $0.userId == peerId }?.name
-                ?? settlement.splits.first { $0.userId == peerId }?.user.name
-                ?? "someone who has left"
+            : members.first { $0.userId == peer.id }?.name ?? peer.name
     }
 
     private var dateText: String {
@@ -116,7 +108,7 @@ struct SettlementDetailView: View {
                 onDeleted()
                 dismiss()
             } catch {
-                errorMessage = ExpenseFormViewModel.message(for: error)
+                errorMessage = error.displayMessage
             }
         }
     }

--- a/Splitty/Splitty/Views/SplitConfigurationView.swift
+++ b/Splitty/Splitty/Views/SplitConfigurationView.swift
@@ -25,8 +25,8 @@ struct SplitConfigurationView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
+                // Save is what an unfinished split blocks; leaving this screen is not.
                 Button("Done") { dismiss() }
-                    .disabled(viewModel.blockingMessage != nil)
             }
         }
         .onAppear {
@@ -132,7 +132,7 @@ struct SplitConfigurationView: View {
                 get: { drafts[member.userId] ?? "" },
                 set: { newValue in
                     drafts[member.userId] = newValue
-                    viewModel.setCustomAmount(cents(from: newValue), for: member.userId)
+                    viewModel.setCustomAmount(max(0, Money.cents(fromTypedText: newValue) ?? 0), for: member.userId)
                 }
             ))
             .keyboardType(.decimalPad)
@@ -155,10 +155,5 @@ struct SplitConfigurationView: View {
         drafts = viewModel.perParticipantAmounts.reduce(into: [:]) { drafts, entry in
             drafts[entry.key] = entry.value > 0 ? Money.plainString(cents: entry.value) : ""
         }
-    }
-
-    private func cents(from text: String) -> Int {
-        guard let value = Decimal(string: text, locale: Locale(identifier: "en_US_POSIX")) else { return 0 }
-        return max(0, Money.cents(from: value))
     }
 }

--- a/Splitty/Splitty/Views/SplitConfigurationView.swift
+++ b/Splitty/Splitty/Views/SplitConfigurationView.swift
@@ -1,0 +1,164 @@
+//
+//  SplitConfigurationView.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// The screen behind the sheet's summary line: who paid, and how the total is divided.
+struct SplitConfigurationView: View {
+    @ObservedObject var viewModel: ExpenseFormViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// Custom amounts are edited as text so a half-typed "1." survives the keystroke that
+    /// would otherwise round it away.
+    @State private var drafts: [Int: String] = [:]
+    @State private var isCustom = false
+
+    var body: some View {
+        List {
+            presetSection
+            payerSection
+            participantSection
+        }
+        .navigationTitle("Split")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Done") { dismiss() }
+                    .disabled(viewModel.blockingMessage != nil)
+            }
+        }
+        .onAppear {
+            isCustom = viewModel.isCustomSplit
+            seedDrafts()
+        }
+        .onChange(of: viewModel.isCustomSplit) { _, nowCustom in
+            isCustom = nowCustom
+            if nowCustom { seedDrafts() }
+        }
+    }
+
+    // MARK: - Presets
+
+    private var presetSection: some View {
+        Section("Preset") {
+            ForEach(SplitPreset.available(memberIds: viewModel.memberIds, currentUserId: viewModel.currentUserId)) { preset in
+                Button {
+                    viewModel.apply(preset: preset, payerId: nil)
+                } label: {
+                    HStack {
+                        Text(preset.title(members: viewModel.members, currentUserId: viewModel.currentUserId))
+                            .foregroundStyle(Color.primary)
+                        Spacer()
+                        if viewModel.selectedPreset == preset {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                }
+                .accessibilityIdentifier("split.preset")
+            }
+        }
+    }
+
+    // MARK: - Payer
+
+    /// The payer need not be one of the participants: "I paid, you all owe me" is a real
+    /// expense, and the API only asks that the payer be a group member.
+    private var payerSection: some View {
+        Section("Paid by") {
+            Picker("Paid by", selection: Binding(
+                get: { viewModel.configuration.payerId },
+                set: { viewModel.setPayer($0) }
+            )) {
+                ForEach(viewModel.members) { member in
+                    Text(name(for: member.userId)).tag(member.userId)
+                }
+            }
+            .pickerStyle(.menu)
+            .accessibilityIdentifier("split.payer")
+        }
+    }
+
+    // MARK: - Participants
+
+    private var participantSection: some View {
+        Section {
+            ForEach(viewModel.members) { member in
+                if isCustom {
+                    customRow(for: member)
+                } else {
+                    equalRow(for: member)
+                }
+            }
+        } header: {
+            Text(isCustom ? "Amounts" : "Split between")
+        } footer: {
+            if let message = viewModel.blockingMessage {
+                Text(message).foregroundStyle(.orange)
+            } else if isCustom {
+                Text("Everything is assigned.")
+            }
+        }
+    }
+
+    private func equalRow(for member: GroupMember) -> some View {
+        let isParticipant = viewModel.isParticipant(member.userId)
+
+        return Button {
+            viewModel.toggleParticipant(member.userId)
+        } label: {
+            HStack {
+                Image(systemName: isParticipant ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isParticipant ? Color.accentColor : Color.secondary)
+                Text(name(for: member.userId))
+                    .foregroundStyle(Color.primary)
+                Spacer()
+                Text(Money.formatted(cents: viewModel.perParticipantAmounts[member.userId] ?? 0))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        }
+        .accessibilityIdentifier("split.member.\(member.userId)")
+    }
+
+    private func customRow(for member: GroupMember) -> some View {
+        HStack {
+            Text(name(for: member.userId))
+            Spacer()
+            Text("$").foregroundStyle(.secondary)
+            TextField("0", text: Binding(
+                get: { drafts[member.userId] ?? "" },
+                set: { newValue in
+                    drafts[member.userId] = newValue
+                    viewModel.setCustomAmount(cents(from: newValue), for: member.userId)
+                }
+            ))
+            .keyboardType(.decimalPad)
+            .multilineTextAlignment(.trailing)
+            .monospacedDigit()
+            .frame(width: 90)
+            .accessibilityIdentifier("split.amount.\(member.userId)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func name(for userId: Int) -> String {
+        userId == viewModel.currentUserId
+            ? "You"
+            : viewModel.members.first { $0.userId == userId }?.name ?? "Unknown"
+    }
+
+    private func seedDrafts() {
+        drafts = viewModel.perParticipantAmounts.reduce(into: [:]) { drafts, entry in
+            drafts[entry.key] = entry.value > 0 ? Money.plainString(cents: entry.value) : ""
+        }
+    }
+
+    private func cents(from text: String) -> Int {
+        guard let value = Decimal(string: text, locale: Locale(identifier: "en_US_POSIX")) else { return 0 }
+        return max(0, Money.cents(from: value))
+    }
+}

--- a/Splitty/SplittyTests/AmountExpressionTests.swift
+++ b/Splitty/SplittyTests/AmountExpressionTests.swift
@@ -1,0 +1,198 @@
+//
+//  AmountExpressionTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+@testable import Splitty
+
+struct AmountExpressionTests {
+
+    // MARK: - Entry
+
+    @Test func startsAtZero() {
+        let expression = AmountExpression()
+        #expect(expression.displayText == "0")
+        #expect(expression.resolvedCents == 0)
+    }
+
+    @Test func typesDigits() {
+        var expression = AmountExpression()
+        expression.type(digit: 1)
+        expression.type(digit: 2)
+        #expect(expression.displayText == "12")
+        #expect(expression.resolvedCents == 1200)
+    }
+
+    @Test func aLeadingDecimalPointGetsAZero() {
+        var expression = AmountExpression()
+        expression.typeDecimalPoint()
+        expression.type(digit: 5)
+        #expect(expression.displayText == "0.5")
+        #expect(expression.resolvedCents == 50)
+    }
+
+    @Test func keepsTheDisplayedTrailingPointWhileTyping() {
+        var expression = AmountExpression()
+        expression.type(digit: 7)
+        expression.typeDecimalPoint()
+        #expect(expression.displayText == "7.")
+        #expect(expression.resolvedCents == 700)
+    }
+
+    @Test func ignoresASecondDecimalPoint() {
+        var expression = AmountExpression()
+        expression.type(digit: 1)
+        expression.typeDecimalPoint()
+        expression.type(digit: 5)
+        expression.typeDecimalPoint()
+        #expect(expression.displayText == "1.5")
+    }
+
+    // Money has two decimal places, so a third digit is not a number the user can mean.
+    @Test func stopsAtTwoDecimalPlaces() {
+        var expression = AmountExpression()
+        expression.type(digit: 1)
+        expression.typeDecimalPoint()
+        expression.type(digit: 2)
+        expression.type(digit: 3)
+        expression.type(digit: 4)
+        #expect(expression.displayText == "1.23")
+    }
+
+    @Test func backspaceRemovesTheLastCharacterAndThenReadsZero() {
+        var expression = AmountExpression()
+        expression.type(digit: 4)
+        expression.type(digit: 2)
+        expression.backspace()
+        #expect(expression.displayText == "4")
+        expression.backspace()
+        #expect(expression.displayText == "0")
+        expression.backspace()
+        #expect(expression.displayText == "0")
+    }
+
+    @Test func clearResetsEverything() {
+        var expression = AmountExpression()
+        expression.type(digit: 9)
+        expression.apply(.add)
+        expression.type(digit: 9)
+        expression.clear()
+        #expect(expression.displayText == "0")
+        #expect(expression.hasPendingExpression == false)
+        #expect(expression.resolvedCents == 0)
+    }
+
+    // MARK: - Chained arithmetic
+
+    // No precedence: 2 + 3 x 4 is 20, because parentheses the user cannot see are worse
+    // than an answer they can follow left to right.
+    @Test func chainsLeftToRightWithNoPrecedence() {
+        var expression = AmountExpression()
+        expression.type(digit: 2)
+        expression.apply(.add)
+        expression.type(digit: 3)
+        expression.apply(.multiply)
+        expression.type(digit: 4)
+        #expect(expression.resolvedCents == 2000)
+    }
+
+    @Test func showsTheRunningTotalOnceAnOperatorIsPressed() {
+        var expression = AmountExpression()
+        expression.type(digit: 2)
+        expression.apply(.add)
+        expression.type(digit: 3)
+        expression.apply(.multiply)
+        #expect(expression.displayText == "5")
+    }
+
+    @Test func equalsResolvesAndLeavesTheResultAsTheEntry() {
+        var expression = AmountExpression()
+        expression.type(digit: 8)
+        expression.apply(.subtract)
+        expression.type(digit: 3)
+        expression.evaluate()
+        #expect(expression.displayText == "5")
+        #expect(expression.hasPendingExpression == false)
+        #expect(expression.resolvedCents == 500)
+    }
+
+    @Test func typingAfterEqualsStartsANewNumber() {
+        var expression = AmountExpression()
+        expression.type(digit: 8)
+        expression.apply(.add)
+        expression.type(digit: 2)
+        expression.evaluate()
+        expression.type(digit: 3)
+        #expect(expression.displayText == "3")
+    }
+
+    @Test func replacesAnOperatorPressedTwice() {
+        var expression = AmountExpression()
+        expression.type(digit: 6)
+        expression.apply(.add)
+        expression.apply(.multiply)
+        expression.type(digit: 2)
+        #expect(expression.resolvedCents == 1200)
+    }
+
+    // Save auto-evaluates, so a dangling operator has to resolve to the left operand
+    // rather than to nothing.
+    @Test func resolvesADanglingOperatorToTheLeftOperand() {
+        var expression = AmountExpression()
+        expression.type(digit: 7)
+        expression.apply(.divide)
+        #expect(expression.hasPendingExpression)
+        #expect(expression.resolvedCents == 700)
+    }
+
+    @Test func roundsARepeatingDivisionToTheNearestCent() {
+        var expression = AmountExpression()
+        expression.type(digit: 1)
+        expression.type(digit: 0)
+        expression.apply(.divide)
+        expression.type(digit: 3)
+        #expect(expression.resolvedCents == 333)
+    }
+
+    @Test func roundsHalfACentUp() {
+        var expression = AmountExpression()
+        expression.type(digit: 5)
+        expression.apply(.divide)
+        expression.type(digit: 8)
+        #expect(expression.resolvedCents == 63) // 0.625
+    }
+
+    // Dividing by zero has no answer to show, so the operator is dropped and the left
+    // operand stands.
+    @Test func dividingByZeroKeepsTheLeftOperand() {
+        var expression = AmountExpression()
+        expression.type(digit: 9)
+        expression.apply(.divide)
+        expression.type(digit: 0)
+        expression.evaluate()
+        #expect(expression.displayText == "9")
+    }
+
+    // MARK: - Seeding
+
+    @Test func seedsFromAnExistingAmount() {
+        let expression = AmountExpression(cents: 4250)
+        #expect(expression.displayText == "42.50")
+        #expect(expression.resolvedCents == 4250)
+    }
+
+    @Test func seedsAWholeAmountWithoutTrailingZeros() {
+        let expression = AmountExpression(cents: 4200)
+        #expect(expression.displayText == "42")
+    }
+
+    @Test func replacesTheWholeEntryWithAPastedAmount() {
+        var expression = AmountExpression()
+        expression.type(digit: 1)
+        expression.replaceEntry(cents: 1999)
+        #expect(expression.displayText == "19.99")
+        #expect(expression.hasPendingExpression == false)
+    }
+}

--- a/Splitty/SplittyTests/ExpenseFormViewModelTests.swift
+++ b/Splitty/SplittyTests/ExpenseFormViewModelTests.swift
@@ -88,7 +88,7 @@ struct ExpenseFormViewModelTests {
         viewModel.amount.type(digit: 0)
         let splits = viewModel.splits()
         #expect(splits.map(\.userId) == [1, 2, 3])
-        #expect(splits.map(\.amount) == [3.34, 3.33, 3.33])
+        #expect(splits.map(\.amountCents) == [334, 333, 333])
     }
 
     // MARK: - Editing
@@ -130,7 +130,7 @@ struct ExpenseFormViewModelTests {
         viewModel.amount.type(digit: 6)
         viewModel.amount.type(digit: 6)
 
-        #expect(viewModel.splits().map(\.amount) == [22.0, 22.0, 22.0])
+        #expect(viewModel.splits().map(\.amountCents) == [2200, 2200, 2200])
     }
 
     // A custom split keeps the numbers a person typed and reports the shortfall instead.

--- a/Splitty/SplittyTests/ExpenseFormViewModelTests.swift
+++ b/Splitty/SplittyTests/ExpenseFormViewModelTests.swift
@@ -1,0 +1,189 @@
+//
+//  ExpenseFormViewModelTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+@testable import Splitty
+
+@MainActor
+struct ExpenseFormViewModelTests {
+
+    private func newExpense(currentUserId: Int = 1) -> ExpenseFormViewModel {
+        ExpenseFormViewModel(groupId: 1, members: TestExpense.members, currentUserId: currentUserId)
+    }
+
+    // MARK: - Creating
+
+    @Test func startsWithYouPayingAndAnEqualSplit() {
+        let viewModel = newExpense()
+        #expect(viewModel.configuration == SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2, 3])))
+        #expect(viewModel.splitSummary == "Paid by you and split equally")
+    }
+
+    @Test func startsWithNothingSaveable() {
+        let viewModel = newExpense()
+        #expect(viewModel.canSave == false)
+        #expect(viewModel.title == "New expense")
+    }
+
+    @Test func needsADescription() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        #expect(viewModel.canSave == false)
+        viewModel.description = "Taxi"
+        #expect(viewModel.canSave)
+    }
+
+    @Test func rejectsADescriptionOfOnlySpaces() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        viewModel.description = "   "
+        #expect(viewModel.canSave == false)
+    }
+
+    @Test func blocksWhenEveryMemberIsUnchecked() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        viewModel.description = "Taxi"
+        viewModel.configuration.mode = .equal(participants: [])
+        #expect(viewModel.canSave == false)
+        #expect(viewModel.blockingMessage == "Select who this is split between")
+    }
+
+    @Test func reportsWhatIsLeftToAssignOnACustomSplit() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 1)
+        viewModel.amount.type(digit: 0)
+        viewModel.description = "Taxi"
+        viewModel.configuration.mode = .custom(amounts: [1: 400])
+        #expect(viewModel.canSave == false)
+        #expect(viewModel.blockingMessage == "$6.00 left to assign")
+    }
+
+    @Test func reportsAnOverAssignedCustomSplit() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 1)
+        viewModel.amount.type(digit: 0)
+        viewModel.description = "Taxi"
+        viewModel.configuration.mode = .custom(amounts: [1: 1200])
+        #expect(viewModel.blockingMessage == "$2.00 over the total")
+    }
+
+    // Refusing to save a number the app can compute is a puzzle, not a safeguard.
+    @Test func autoEvaluatesAPendingExpression() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 6)
+        viewModel.amount.apply(.divide)
+        viewModel.amount.type(digit: 4)
+        viewModel.description = "Taxi"
+        #expect(viewModel.canSave)
+        #expect(viewModel.totalCents == 150)
+    }
+
+    @Test func splitsTheResolvedTotal() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 1)
+        viewModel.amount.type(digit: 0)
+        let splits = viewModel.splits()
+        #expect(splits.map(\.userId) == [1, 2, 3])
+        #expect(splits.map(\.amount) == [3.34, 3.33, 3.33])
+    }
+
+    // MARK: - Editing
+
+    @Test func seedsFromAnExistingExpense() {
+        let expense = TestExpense.make(
+            paidBy: 2,
+            amount: 66,
+            splitAmounts: [1: 40, 2: 26],
+            date: "2026-07-04T10:30:00Z"
+        )
+        let viewModel = ExpenseFormViewModel(
+            groupId: 1,
+            members: TestExpense.members,
+            currentUserId: 1,
+            expense: expense
+        )
+
+        #expect(viewModel.title == "Edit expense")
+        #expect(viewModel.amount.displayText == "66")
+        #expect(viewModel.description == "Dinner")
+        #expect(viewModel.configuration == SplitConfiguration(payerId: 2, mode: .custom(amounts: [1: 4000, 2: 2600])))
+        #expect(viewModel.date == Expense.parseTimestamp("2026-07-04T10:30:00Z"))
+        #expect(viewModel.canSave)
+    }
+
+    // Reopening an equal split and changing the total keeps it equal — one gesture, which
+    // is the whole reason the mode is inferred rather than stored.
+    @Test func rederivesAnEqualSplitWhenTheTotalChanges() {
+        let expense = TestExpense.make(paidBy: 1, amount: 60, splitAmounts: [1: 20, 2: 20, 3: 20])
+        let viewModel = ExpenseFormViewModel(
+            groupId: 1,
+            members: TestExpense.members,
+            currentUserId: 1,
+            expense: expense
+        )
+
+        viewModel.amount.clear()
+        viewModel.amount.type(digit: 6)
+        viewModel.amount.type(digit: 6)
+
+        #expect(viewModel.splits().map(\.amount) == [22.0, 22.0, 22.0])
+    }
+
+    // A custom split keeps the numbers a person typed and reports the shortfall instead.
+    @Test func keepsCustomAmountsWhenTheTotalChanges() {
+        let expense = TestExpense.make(paidBy: 1, amount: 60, splitAmounts: [1: 40, 2: 20])
+        let viewModel = ExpenseFormViewModel(
+            groupId: 1,
+            members: TestExpense.members,
+            currentUserId: 1,
+            expense: expense
+        )
+
+        viewModel.amount.clear()
+        viewModel.amount.type(digit: 6)
+        viewModel.amount.type(digit: 6)
+
+        #expect(viewModel.configuration.mode == .custom(amounts: [1: 4000, 2: 2000]))
+        #expect(viewModel.blockingMessage == "$6.00 left to assign")
+    }
+
+    // MARK: - Presets
+
+    @Test func applyingAPresetReplacesThePayerAndTheMode() {
+        let viewModel = newExpense()
+        viewModel.apply(preset: .someoneElsePaidSplitEqually, payerId: 3)
+        #expect(viewModel.configuration == SplitConfiguration(payerId: 3, mode: .equal(participants: [1, 2, 3])))
+        #expect(viewModel.selectedPreset == .someoneElsePaidSplitEqually)
+    }
+
+    // Switching to custom seeds the rows from the equal division rather than from nothing:
+    // adjusting two numbers beats typing every one of them.
+    @Test func customSeedsFromWhateverTheSplitCurrentlyIs() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        viewModel.apply(preset: .custom, payerId: nil)
+        #expect(viewModel.configuration.mode == .custom(amounts: [1: 300, 2: 300, 3: 300]))
+        #expect(viewModel.canSave == false) // description still empty
+        #expect(viewModel.blockingMessage == nil)
+    }
+
+    @Test func togglingAMemberOffRederivesAcrossTheRest() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        viewModel.toggleParticipant(2)
+        #expect(viewModel.configuration.mode == .equal(participants: [1, 3]))
+        #expect(viewModel.splits().map(\.userId) == [1, 3])
+    }
+
+    @Test func togglingWithACustomSplitZeroesThatRow() {
+        let viewModel = newExpense()
+        viewModel.amount.type(digit: 9)
+        viewModel.apply(preset: .custom, payerId: nil)
+        viewModel.toggleParticipant(2)
+        #expect(viewModel.configuration.mode == .custom(amounts: [1: 300, 2: 0, 3: 300]))
+    }
+}

--- a/Splitty/SplittyTests/ExpenseTimelineTests.swift
+++ b/Splitty/SplittyTests/ExpenseTimelineTests.swift
@@ -1,0 +1,81 @@
+//
+//  ExpenseTimelineTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+@testable import Splitty
+
+@MainActor
+struct ExpenseTimelineTests {
+
+    // The saved row is real — the server returned it — so it appears without waiting for
+    // the refetch that follows the sheet's dismissal.
+    @Test func insertingAnExpenseShowsItImmediately() {
+        let viewModel = GroupViewModel()
+        viewModel.insert(TestExpense.make(id: 9, paidBy: 1, amount: 30, splitAmounts: [1: 30]))
+
+        #expect(viewModel.expenses.map(\.id) == [9])
+        #expect(viewModel.groupedExpenses.flatMap { $0.expenses }.map(\.id) == [9])
+    }
+
+    @Test func insertingAnEditedExpenseReplacesTheRowRatherThanDoublingIt() {
+        let viewModel = GroupViewModel()
+        viewModel.insert(TestExpense.make(id: 9, paidBy: 1, amount: 30, splitAmounts: [1: 30]))
+        viewModel.insert(TestExpense.make(id: 9, paidBy: 1, amount: 45, splitAmounts: [1: 45]))
+
+        #expect(viewModel.expenses.map(\.amount) == [45])
+    }
+}
+
+struct ExpenseReadingTests {
+
+    // A settlement's splits are [+amount, -amount], so the counterparty is the one that is
+    // not the payer's.
+    @Test func readsTheCounterpartyOffASettlement() {
+        let settlement = TestExpense.make(paidBy: 2, amount: 10, splitAmounts: [2: 10, 3: -10], type: .payment)
+        #expect(settlement.peer?.id == 3)
+    }
+
+    @Test func hasNoCounterpartyWhenNobodyElseCarriesASplit() {
+        let expense = TestExpense.make(paidBy: 2, amount: 10, splitAmounts: [2: 10])
+        #expect(expense.peer == nil)
+    }
+
+    // The payer lent the total less their own share; everyone else borrowed theirs.
+    @Test func readsWhatThePayerLent() {
+        let expense = TestExpense.make(paidBy: 1, amount: 30, splitAmounts: [1: 10, 2: 20])
+        #expect(expense.getUserSplit(currentUserId: 1) == 20)
+        #expect(expense.getUserSplit(currentUserId: 2) == -20)
+    }
+
+    // Files under the user-supplied date when there is one, the audit timestamp otherwise.
+    @Test func fallsBackToTheAuditTimestampWithoutADate() {
+        let undated = TestExpense.make(paidBy: 1, amount: 10, splitAmounts: [1: 10])
+        #expect(undated.effectiveDate == Expense.parseTimestamp("2026-08-20T12:00:00Z"))
+
+        let dated = TestExpense.make(paidBy: 1, amount: 10, splitAmounts: [1: 10], date: "2026-07-04T10:30:00Z")
+        #expect(dated.effectiveDate == Expense.parseTimestamp("2026-07-04T10:30:00Z"))
+    }
+}
+
+struct APIErrorMessageTests {
+
+    // The server's own 400 is the only thing that knows why a split the client believed in
+    // was refused, so it is what goes on screen.
+    @Test func prefersTheServersOwnExplanation() {
+        let error = APIError.httpError(400, message: "Expense splits must sum to the total.")
+        #expect(error.displayMessage == "Expense splits must sum to the total.")
+    }
+
+    @Test func fallsBackToCopyOfItsOwnWhenTheServerSaidNothing() {
+        #expect(APIError.httpError(403, message: nil).displayMessage == "You are not a member of this group.")
+        #expect(APIError.httpError(500, message: nil).displayMessage == "Something went wrong (500). Try again.")
+    }
+
+    @Test func readsAnErrorThatIsNotAnAPIError() {
+        struct Sad: LocalizedError { var errorDescription: String? { "Sad" } }
+        #expect(Sad().displayMessage == "Sad")
+    }
+}

--- a/Splitty/SplittyTests/MoneyRequestValueTests.swift
+++ b/Splitty/SplittyTests/MoneyRequestValueTests.swift
@@ -1,0 +1,52 @@
+//
+//  MoneyRequestValueTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+
+@testable import Splitty
+
+@Suite("Money request values")
+struct MoneyRequestValueTests {
+    /// The bug this exists for: `JSONSerialization` prints a `Double` to 17 significant
+    /// digits, so a third of 25 went out as 8.3300000000000001 and the API — which parses
+    /// into `decimal`, keeping all of it — rejected three of them for not summing to 25.
+    @Test("serialises to the decimal it holds, not to a double's expansion")
+    func serialisesExactly() throws {
+        let body = ["amount": Money.requestValue(cents: 833)]
+        let json = String(
+            data: try JSONSerialization.data(withJSONObject: body),
+            encoding: .utf8
+        )
+
+        #expect(json == #"{"amount":8.33}"#)
+    }
+
+    @Test("an equal split still reads as the total once serialised")
+    func equalSplitSurvivesSerialisation() throws {
+        let amounts = SplitConfiguration.equalAmounts(totalCents: 2500, among: [1, 2, 3])
+        let body: [String: Any] = [
+            "amount": Money.requestValue(cents: 2500),
+            "splits": amounts.values.sorted().map { ["amount": Money.requestValue(cents: $0)] }
+        ]
+
+        let json = String(
+            data: try JSONSerialization.data(withJSONObject: body),
+            encoding: .utf8
+        )!
+
+        #expect(json.contains("8.33"))
+        #expect(json.contains("8.34"))
+        #expect(!json.contains("8.3300"))
+        #expect(!json.contains("25.0000"))
+    }
+
+    @Test("whole amounts keep their scale")
+    func wholeAmounts() {
+        #expect(Money.requestValue(cents: 2500).stringValue == "25")
+        #expect(Money.requestValue(cents: 1250).stringValue == "12.5")
+        #expect(Money.requestValue(cents: 7).stringValue == "0.07")
+    }
+}

--- a/Splitty/SplittyTests/SplitConfigurationTests.swift
+++ b/Splitty/SplittyTests/SplitConfigurationTests.swift
@@ -1,0 +1,247 @@
+//
+//  SplitConfigurationTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+@testable import Splitty
+
+struct SplitConfigurationTests {
+
+    // MARK: - Equal division
+
+    @Test func dividesEvenlyWhenItDivides() {
+        let amounts = SplitConfiguration.equalAmounts(totalCents: 3000, among: [7, 3, 5])
+        #expect(amounts == [3: 1000, 5: 1000, 7: 1000])
+    }
+
+    // Remainder cents go to the first participants by ascending user id: deterministic,
+    // device-independent, and not biased toward whoever happened to pay.
+    @Test func givesRemainderCentsToTheLowestUserIds() {
+        let amounts = SplitConfiguration.equalAmounts(totalCents: 1000, among: [9, 2, 4])
+        #expect(amounts == [2: 334, 4: 333, 9: 333])
+        #expect(amounts.values.reduce(0, +) == 1000)
+    }
+
+    @Test func alwaysSumsToTheTotal() {
+        for total in [1, 2, 7, 99, 100, 101, 1234, 99999] {
+            for count in 1...7 {
+                let ids = Array(1...count)
+                let amounts = SplitConfiguration.equalAmounts(totalCents: total, among: ids)
+                #expect(amounts.values.reduce(0, +) == total)
+            }
+        }
+    }
+
+    @Test func dividesNothingAmongNobody() {
+        #expect(SplitConfiguration.equalAmounts(totalCents: 1000, among: []).isEmpty)
+    }
+
+    // MARK: - Payload
+
+    @Test func buildsOneSplitPerParticipant() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2]))
+        let splits = configuration.splits(totalCents: 1000)
+        #expect(splits.map(\.userId) == [1, 2])
+        #expect(splits.map(\.amount) == [5.0, 5.0])
+    }
+
+    // The payer need not be a participant: "I paid, you all owe me" is a real expense, and
+    // the API only requires the payer to be a group member.
+    @Test func allowsAPayerWhoIsNotAParticipant() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [2, 3]))
+        let splits = configuration.splits(totalCents: 1000)
+        #expect(splits.map(\.userId) == [2, 3])
+    }
+
+    // Splits must be greater than zero, so a member who would land on nothing is left out
+    // of the array rather than sent as a zero the server rejects.
+    @Test func omitsParticipantsWhoLandOnZeroCents() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2, 3, 4, 5]))
+        let splits = configuration.splits(totalCents: 3)
+        #expect(splits.map(\.userId) == [1, 2, 3])
+        #expect(splits.map(\.amount) == [0.01, 0.01, 0.01])
+    }
+
+    @Test func omitsCustomAmountsLeftAtZero() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 0, 2: 1000]))
+        #expect(configuration.splits(totalCents: 1000).map(\.userId) == [2])
+    }
+
+    // MARK: - Blocking save
+
+    @Test func blocksAnAmountOfZero() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2]))
+        #expect(configuration.blockingReason(totalCents: 0) == .amountNotPositive)
+    }
+
+    // Unchecking everyone disables Save rather than sending an empty array.
+    @Test func blocksWhenNobodyIsChecked() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: []))
+        #expect(configuration.blockingReason(totalCents: 1000) == .noParticipants)
+    }
+
+    @Test func allowsAnEqualSplitWithAtLeastOneParticipant() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [2]))
+        #expect(configuration.blockingReason(totalCents: 1000) == nil)
+    }
+
+    @Test func blocksACustomSplitThatDoesNotReachTheTotal() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 400, 2: 400]))
+        #expect(configuration.blockingReason(totalCents: 1000) == .unassigned(cents: 200))
+    }
+
+    @Test func blocksACustomSplitThatOvershootsTheTotal() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 900, 2: 400]))
+        #expect(configuration.blockingReason(totalCents: 1000) == .unassigned(cents: -300))
+    }
+
+    @Test func allowsACustomSplitThatLandsExactly() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 600, 2: 400]))
+        #expect(configuration.blockingReason(totalCents: 1000) == nil)
+    }
+
+    @Test func blocksACustomSplitOfNothingButZeros() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 0, 2: 0]))
+        #expect(configuration.blockingReason(totalCents: 0) == .amountNotPositive)
+    }
+
+    // Changing the total after typing custom amounts keeps the typed numbers and reports
+    // the shortfall. Rescaling would silently rewrite figures a person chose deliberately.
+    @Test func keepsCustomAmountsWhenTheTotalChanges() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 3000, 2: 3000]))
+        #expect(configuration.blockingReason(totalCents: 6600) == .unassigned(cents: 600))
+        #expect(configuration.amounts(totalCents: 6600) == [1: 3000, 2: 3000])
+    }
+
+    // MARK: - Inference from a stored expense
+
+    @Test func readsAnEvenlyDividedExpenseAsEqual() {
+        let expense = TestExpense.make(paidBy: 1, amount: 30, splitAmounts: [1: 10, 2: 10, 3: 10])
+        let configuration = SplitConfiguration(inferredFrom: expense)
+        #expect(configuration.payerId == 1)
+        #expect(configuration.mode == .equal(participants: [1, 2, 3]))
+    }
+
+    // A remainder cent is still an equal split — the whole point of distributing it.
+    @Test func readsARemainderCentAsEqual() {
+        let expense = TestExpense.make(paidBy: 2, amount: 10, splitAmounts: [1: 3.34, 2: 3.33, 3: 3.33])
+        #expect(SplitConfiguration(inferredFrom: expense).mode == .equal(participants: [1, 2, 3]))
+    }
+
+    @Test func readsUnevenAmountsAsCustom() {
+        let expense = TestExpense.make(paidBy: 1, amount: 30, splitAmounts: [1: 20, 2: 10])
+        #expect(SplitConfiguration(inferredFrom: expense).mode == .custom(amounts: [1: 2000, 2: 1000]))
+    }
+
+    @Test func readsASingleSplitAsEqual() {
+        let expense = TestExpense.make(paidBy: 1, amount: 30, splitAmounts: [2: 30])
+        #expect(SplitConfiguration(inferredFrom: expense).mode == .equal(participants: [2]))
+    }
+
+    // MARK: - Presets
+
+    @Test func offersTheFullAmountPresetsOnlyToTwoPersonGroups() {
+        let pair = SplitPreset.available(memberIds: [1, 2], currentUserId: 1)
+        #expect(pair.contains(.youPaidTheyOweFull))
+        #expect(pair.contains(.theyPaidYouOweFull))
+
+        let trio = SplitPreset.available(memberIds: [1, 2, 3], currentUserId: 1)
+        #expect(!trio.contains(.youPaidTheyOweFull))
+        #expect(!trio.contains(.theyPaidYouOweFull))
+        #expect(trio == [.youPaidSplitEqually, .someoneElsePaidSplitEqually, .custom])
+    }
+
+    @Test func youPaidSplitEquallyPaysAndParticipates() {
+        let configuration = SplitPreset.youPaidSplitEqually.configuration(memberIds: [1, 2, 3], currentUserId: 2)
+        #expect(configuration == SplitConfiguration(payerId: 2, mode: .equal(participants: [1, 2, 3])))
+    }
+
+    @Test func youPaidTheyOweTheFullAmountLeavesYouOutOfTheSplits() {
+        let configuration = SplitPreset.youPaidTheyOweFull.configuration(memberIds: [1, 2], currentUserId: 1)
+        #expect(configuration == SplitConfiguration(payerId: 1, mode: .equal(participants: [2])))
+    }
+
+    @Test func theyPaidYouOweTheFullAmountPutsThePayerOutOfTheSplits() {
+        let configuration = SplitPreset.theyPaidYouOweFull.configuration(memberIds: [1, 2], currentUserId: 1)
+        #expect(configuration == SplitConfiguration(payerId: 2, mode: .equal(participants: [1])))
+    }
+
+    // MARK: - Summary line
+
+    @Test func summarisesTheDefault() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2, 3]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by you and split equally")
+    }
+
+    @Test func namesAnotherPayer() {
+        let configuration = SplitConfiguration(payerId: 2, mode: .equal(participants: [1, 2, 3]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by Bob and split equally")
+    }
+
+    @Test func summarisesAPartialEqualSplit() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by you and split equally between 2 people")
+    }
+
+    @Test func summarisesOneOtherPersonOwingEverything() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [2]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by you, Bob owes the full amount")
+    }
+
+    @Test func summarisesYouOwingEverything() {
+        let configuration = SplitConfiguration(payerId: 2, mode: .equal(participants: [1]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by Bob, you owe the full amount")
+    }
+
+    @Test func summarisesACustomSplit() {
+        let configuration = SplitConfiguration(payerId: 1, mode: .custom(amounts: [1: 600, 2: 400]))
+        #expect(configuration.summary(members: TestExpense.members, currentUserId: 1)
+                == "Paid by you and split by amounts")
+    }
+}
+
+// MARK: - Fixtures
+
+enum TestExpense {
+    static let members = [
+        GroupMember(id: 11, userId: 1, name: "Alice", email: "alice@example.com", avatarUrl: ""),
+        GroupMember(id: 12, userId: 2, name: "Bob", email: "bob@example.com", avatarUrl: ""),
+        GroupMember(id: 13, userId: 3, name: "Cara", email: "cara@example.com", avatarUrl: "")
+    ]
+
+    static func user(_ id: Int) -> User {
+        User(id: id, name: "User \(id)", email: "user\(id)@example.com", createdAt: "", updatedAt: "")
+    }
+
+    static func make(
+        id: Int = 1,
+        paidBy: Int,
+        amount: Double,
+        splitAmounts: [Int: Double],
+        type: ExpenseType = .expense,
+        date: String? = nil
+    ) -> Expense {
+        Expense(
+            id: id,
+            groupId: 1,
+            paidBy: paidBy,
+            amount: amount,
+            description: "Dinner",
+            type: type,
+            date: date,
+            createdAt: "2026-08-20T12:00:00Z",
+            updatedAt: "2026-08-20T12:00:00Z",
+            paidByUser: user(paidBy),
+            splits: splitAmounts.sorted { $0.key < $1.key }.enumerated().map { index, entry in
+                ExpenseSplit(id: index + 1, expenseId: id, userId: entry.key, amount: entry.value, user: user(entry.key))
+            }
+        )
+    }
+}

--- a/Splitty/SplittyTests/SplitConfigurationTests.swift
+++ b/Splitty/SplittyTests/SplitConfigurationTests.swift
@@ -44,7 +44,7 @@ struct SplitConfigurationTests {
         let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2]))
         let splits = configuration.splits(totalCents: 1000)
         #expect(splits.map(\.userId) == [1, 2])
-        #expect(splits.map(\.amount) == [5.0, 5.0])
+        #expect(splits.map(\.amountCents) == [500, 500])
     }
 
     // The payer need not be a participant: "I paid, you all owe me" is a real expense, and
@@ -61,7 +61,7 @@ struct SplitConfigurationTests {
         let configuration = SplitConfiguration(payerId: 1, mode: .equal(participants: [1, 2, 3, 4, 5]))
         let splits = configuration.splits(totalCents: 3)
         #expect(splits.map(\.userId) == [1, 2, 3])
-        #expect(splits.map(\.amount) == [0.01, 0.01, 0.01])
+        #expect(splits.map(\.amountCents) == [1, 1, 1])
     }
 
     @Test func omitsCustomAmountsLeftAtZero() {


### PR DESCRIPTION
Closes #18.

The expense drawer: create and edit an expense from a sheet that opens on the amount, with a pad of its own.

## The sheet

- **Amount** — a hero figure drawn one glyph at a time, so a digit that changes animates on its own while the rest hold still. The currency sits trailing at the same size as the digits.
- **Pad** — digits only. The arithmetic keys the issue asked for are gone: chained operators with no precedence and no visible expression made the user hold state the sheet never showed them. `AmountExpression` keeps its operators, so nothing about how an amount resolves changed — only what the pad can send.
- **One action.** The arrow advances from the amount to the description, and saves once the description has focus. There is no Cancel and no Save in a navigation bar; the sheet dismisses by dragging.
- **Date** — a pill in the header reading `Today`, opening a full-size picker from the bottom.
- **Split** — a pushed screen with presets, per-member checkboxes, and custom-by-value with a live "left to assign".

The pad is sheet content, not a keyboard. Hosted in a `UITextField.inputView` the system owned its dismissal, and it slid out on the keyboard's clock from under a sheet that was still on screen. As content it travels with the sheet, and the sheet answers keyboard frame notifications itself rather than letting avoidance move two things at once.

## Money

Amounts are integer cents everywhere, converted once at the request boundary — and converted to `NSDecimalNumber`, not `Double`. `JSONSerialization` prints a double to 17 significant digits, so a third of 25 left as `8.3300000000000001`, and the API parses amounts into `decimal`, which keeps every one of those digits. Three of them do not sum to 25, so the default split — paid by you, split equally — failed to save with "Expense splits must sum to the total" on an expense whose cents were exact the whole way.

## Timeline

- Expense and settlement detail screens, with edit and delete.
- Rows are square, edge to edge, and have no disclosure chevron. `SwipeToDeleteRow` replaces `.swipeActions`, which draws a rounded inset button; the drag brings the delete in with the card, and releasing past the threshold asks in an alert naming what it is about.
- The header balance greys while a recomputation is pending, refetched once on dismissal rather than polled.

## Also

- Real identity replaces the hardcoded `currentUserId`. `getProfile` points at `GET /auth`; `updateProfile` is deleted.
- The server's `400` is rendered inline, in both body shapes the API returns.
- `SPLITTY_API_BASE_URL` points at `https://splitty.snowye.dev` in Debug and Release. Release was empty, which throws at the first request.

## Tests

Unit coverage for the amount expression, split configuration and inference, the form view model, the timeline, and the request encoding that this branch fixes. The UIKit glue and the gestures were exercised on the simulator with throwaway UI tests, which are not part of the diff.

## Worth a look

**That deployment runs as Development.** `/openapi/v1.json` and `/scalar/v1` both answer, and the same gate registers `DevAuthController` — so `POST /auth/dev-login` on a public host mints a JWT for any email in that database, with no credential. Harmless only while the database has no users. Not addressed here; it belongs to the API side.