### PR TITLE
feat(ios): trade the tab bar for three flat icons

### DIFF
--- a/Splitty/Splitty.xcodeproj/project.pbxproj
+++ b/Splitty/Splitty.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		09A1B2C43001DB6E0066C78D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 09A1B2C33001DB6E0066C78D /* GoogleSignIn */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		0955FC982D5584AD002471A6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -59,10 +63,6 @@
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
-
-/* Begin PBXBuildFile section */
-		09A1B2C43001DB6E0066C78D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 09A1B2C33001DB6E0066C78D /* GoogleSignIn */; };
-/* End PBXBuildFile section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0955FC842D5584AC002471A6 /* Frameworks */ = {
@@ -584,14 +584,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCSwiftPackageProductDependency section */
-		09A1B2C33001DB6E0066C78D /* GoogleSignIn */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
-			productName = GoogleSignIn;
-		};
-/* End XCSwiftPackageProductDependency section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -610,6 +602,14 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		09A1B2C33001DB6E0066C78D /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 091693F13037DB6E0066C78D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 0955FC7F2D5584AC002471A6 /* Project object */;
 }

--- a/Splitty/Splitty/Components/BottomBar.swift
+++ b/Splitty/Splitty/Components/BottomBar.swift
@@ -1,0 +1,78 @@
+//
+//  BottomBar.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// Flat, monochrome tab bar pinned to the bottom edge.
+struct BottomBar: View {
+    @Binding var selection: AppTab
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(AppTab.allCases, id: \.rawValue) { tab in
+                BottomBarItem(tab: tab, isSelected: tab == selection) {
+                    selection = tab
+                }
+            }
+        }
+        .padding(.top, 12)
+        .padding(.bottom, 4)
+        .padding(.horizontal, 8)
+        .background(alignment: .top) {
+            ZStack(alignment: .top) {
+                Color("background")
+                Rectangle()
+                    .fill(Color("border"))
+                    .frame(height: 0.5)
+            }
+            .ignoresSafeArea(edges: .bottom)
+        }
+    }
+}
+
+private struct BottomBarItem: View {
+    let tab: AppTab
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: tab.icon)
+                .font(.system(size: 20, weight: isSelected ? .semibold : .regular))
+                .foregroundColor(isSelected ? Color("foreground") : Color("muted-foreground"))
+                .frame(maxWidth: .infinity)
+                .frame(height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(tab.title)
+        .animation(.easeOut(duration: 0.15), value: isSelected)
+    }
+}
+
+#Preview {
+    StatefulPreviewWrapper(AppTab.groups) { binding in
+        VStack {
+            Spacer()
+            BottomBar(selection: binding)
+        }
+        .background(Color("background"))
+    }
+}
+
+/// Small helper so previews can drive a `@Binding`.
+struct StatefulPreviewWrapper<Value, Content: View>: View {
+    @State private var value: Value
+    private let content: (Binding<Value>) -> Content
+
+    init(_ value: Value, @ViewBuilder content: @escaping (Binding<Value>) -> Content) {
+        _value = State(initialValue: value)
+        self.content = content
+    }
+
+    var body: some View {
+        content($value)
+    }
+}

--- a/Splitty/Splitty/Components/GroupCard.swift
+++ b/Splitty/Splitty/Components/GroupCard.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct GroupCard: View {
     let group: Group
+    let onTap: () -> Void
     
     var positiveBalance: Bool {
         return (group.netBalance) > 0;
     }
     
     var body: some View {
-        NavigationLink(value: group.id) {
+        Button(action: onTap) {
             VStack {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading) {
@@ -67,7 +68,7 @@ struct GroupCard: View {
                 avatarUrl: "https://github.com/Sn0wye.png"
             )
         ]
-    ))
+    ), onTap: {})
     
     GroupCard(group: Group(
         id: 1,
@@ -84,6 +85,6 @@ struct GroupCard: View {
                 avatarUrl: "https://github.com/ruymon.png"
             )
         ]
-    ))
+    ), onTap: {})
 
 }

--- a/Splitty/Splitty/ContentView.swift
+++ b/Splitty/Splitty/ContentView.swift
@@ -8,19 +8,53 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var appState = AppState()
+
     var body: some View {
-        TabView {
-            GroupsView()
-                .tabItem {
-                    Image(systemName: "person.2.fill")
-                    Text("Groups")
+        // A VStack, not a safeAreaInset: an inset is something content draws under,
+        // and a list does exactly that, taking anything anchored to its bottom edge
+        // (the add button) behind the bar with it. Stacked, the bar owns its space.
+        VStack(spacing: 0) {
+            ZStack {
+                switch appState.selectedTab {
+                case .groups:
+                    GroupsView()
+                case .group:
+                    CurrentGroupView()
+                case .settings:
+                    SettingsView()
                 }
-            
-            SettingsView()
-                .tabItem {
-                    Image(systemName: "gear")
-                    Text("Settings")
-                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            BottomBar(selection: $appState.selectedTab)
+        }
+        .background(Color("background").ignoresSafeArea())
+        .environmentObject(appState)
+    }
+}
+
+/// The "Group" tab: renders whichever group was last opened.
+private struct CurrentGroupView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        if let groupId = appState.currentGroupId {
+            GroupView(groupId: groupId)
+                .id(groupId)
+        } else {
+            VStack(spacing: 8) {
+                Image(systemName: "person.2")
+                    .font(.system(size: 32, weight: .light))
+                Text("No group selected")
+                    .font(.headline)
+                Text("Pick a group from the Groups tab.")
+                    .font(.subheadline)
+                    .foregroundColor(Color("muted-foreground"))
+            }
+            .foregroundColor(Color("foreground"))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color("background"))
         }
     }
 }

--- a/Splitty/Splitty/State/AppState.swift
+++ b/Splitty/Splitty/State/AppState.swift
@@ -1,0 +1,57 @@
+//
+//  AppState.swift
+//  Splitty
+//
+
+import SwiftUI
+
+enum AppTab: Int, CaseIterable {
+    case groups
+    case group
+    case settings
+
+    var title: String {
+        switch self {
+        case .groups: return "Groups"
+        case .group: return "Group"
+        case .settings: return "Settings"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .groups: return "square.grid.2x2"
+        case .group: return "person.2"
+        case .settings: return "gearshape"
+        }
+    }
+}
+
+/// Shared navigation state: which tab is showing and which group the
+/// "Group" tab is currently pointing at.
+@MainActor
+final class AppState: ObservableObject {
+    private static let currentGroupKey = "currentGroupId"
+
+    @Published var selectedTab: AppTab = .groups
+
+    @Published var currentGroupId: Int? {
+        didSet {
+            if let id = currentGroupId {
+                UserDefaults.standard.set(id, forKey: Self.currentGroupKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.currentGroupKey)
+            }
+        }
+    }
+
+    init() {
+        let stored = UserDefaults.standard.object(forKey: Self.currentGroupKey) as? Int
+        currentGroupId = stored
+    }
+
+    func openGroup(_ id: Int) {
+        currentGroupId = id
+        selectedTab = .group
+    }
+}

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -9,52 +9,74 @@ import SwiftUI
 
 struct GroupView: View {
     let groupId: Int
+    @EnvironmentObject private var appState: AppState
     @StateObject private var viewModel = GroupViewModel()
     @StateObject private var authManager = AuthenticationManager.shared
-    @Environment(\.dismiss) private var dismiss
+    @State private var isTitleCollapsed = false
     @State private var showingEditSheet = false
     @State private var showingExpenseSheet = false
     @State private var pendingDeletion: Expense?
     @State private var selectedExpenseId: Int?
 
-    /// The floating button clears the last row rather than covering it.
-    private let listBottomInset: CGFloat = 88
+    private let addButtonSize: CGFloat = 56
+
+    /// Roughly the height of the in-list title, so the toolbar picks the name up
+    /// as the header leaves rather than while it is still readable.
+    private let titleCollapseOffset: CGFloat = 52
 
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            Color("background")
-                .ignoresSafeArea()
-            
+        NavigationStack {
+            groupScreen
+        }
+    }
+
+    private var groupScreen: some View {
+        ZStack {
             if viewModel.isLoading {
                 ProgressView("Loading...")
                     .foregroundColor(Color("foreground"))
             } else {
                 content
             }
-
-            // The screen's primary action does not belong in a toolbar already carrying
-            // Back and Edit, and a floating button survives the list scrolling.
-            addExpenseButton
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // The background ignores the safe area, the stack does not: otherwise the
+        // floating button anchors below the tab bar instead of above it.
+        .background(Color("background").ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
+        // Without this the bar is a material: rows scrolling under it stay visible
+        // as a smear behind the status bar.
+        .toolbarBackground(Color("background"), for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: { dismiss() }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                        Text("Groups")
-                    }
-                    .foregroundColor(Color("foreground"))
+                Button {
+                    appState.selectedTab = .groups
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundColor(Color("foreground"))
                 }
+                .accessibilityLabel("Back to groups")
             }
-            
+
+            ToolbarItem(placement: .principal) {
+                Text(viewModel.group?.name ?? "")
+                    .font(.headline)
+                    .foregroundColor(Color("foreground"))
+                    .opacity(isTitleCollapsed ? 1 : 0)
+            }
+
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Edit") {
+                Button {
                     showingEditSheet = true
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundColor(Color("foreground"))
                 }
-                .foregroundColor(Color("foreground"))
                 .disabled(viewModel.group == nil)
+                .accessibilityLabel("Edit group")
             }
         }
         .sheet(isPresented: $showingEditSheet) {
@@ -150,15 +172,24 @@ struct GroupView: View {
                 }
             }
 
-            Color.clear
-                .frame(height: listBottomInset)
-                .listRowInsets(EdgeInsets())
-                .listRowBackground(Color("card"))
-                .listRowSeparator(.hidden)
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(Color("background"))
+        // A list draws itself under the safe area, so a button stacked on top of one
+        // anchors under the tab bar. As an inset it sits inside the safe area instead,
+        // and the space it reserves is exactly what keeps the last row uncovered.
+        .safeAreaInset(edge: .bottom, alignment: .trailing, spacing: 0) {
+            addExpenseButton
+        }
+        // The title lives in the list, not in a large-title bar, so the handoff to the
+        // toolbar is driven off the scroll position.
+        .onScrollGeometryChange(for: Bool.self) { geometry in
+            geometry.contentOffset.y + geometry.contentInsets.top > titleCollapseOffset
+        } action: { _, collapsed in
+            guard collapsed != isTitleCollapsed else { return }
+            withAnimation(.easeInOut(duration: 0.2)) { isTitleCollapsed = collapsed }
+        }
         .navigationDestination(item: $selectedExpenseId) { expenseId in
             if let currentUserId {
                 detail(for: expenseId, currentUserId: currentUserId)
@@ -227,13 +258,13 @@ struct GroupView: View {
             Image(systemName: "plus")
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundColor(Color("background"))
-                .frame(width: 56, height: 56)
+                .frame(width: addButtonSize, height: addButtonSize)
                 .background(Color("foreground"))
                 .clipShape(Circle())
                 .shadow(radius: 8, y: 4)
         }
         .padding(.trailing, 20)
-        .padding(.bottom, 24)
+        .padding(.vertical, 16)
         .disabled(currentUserId == nil || viewModel.group == nil)
         .accessibilityIdentifier("group.addExpense")
         .accessibilityLabel("Add expense")
@@ -500,4 +531,5 @@ struct RoundedCorner: Shape {
 
 #Preview {
     GroupView(groupId: 1)
+        .environmentObject(AppState())
 }

--- a/Splitty/Splitty/Views/GroupsView.swift
+++ b/Splitty/Splitty/Views/GroupsView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct GroupsView: View {
     @StateObject private var viewModel = GroupsViewModel()
-    @State private var path: [Int] = []
+    @EnvironmentObject private var appState: AppState
     @State private var showingCreateSheet = false
     @State private var showingJoinSheet = false
     
     var body: some View {
-        NavigationStack(path: $path) {
+        NavigationStack {
             VStack(alignment: .leading) {
 
                 HStack {
@@ -46,7 +46,9 @@ struct GroupsView: View {
                 ScrollView {
                     VStack(spacing: 10) {
                         ForEach(viewModel.groups) { group in
-                            GroupCard(group: group)
+                            GroupCard(group: group) {
+                                appState.openGroup(group.id)
+                            }
                         }
                     }
                 }
@@ -57,15 +59,12 @@ struct GroupsView: View {
                 Spacer()
             }
             .background(Color("background").ignoresSafeArea())
-            .navigationDestination(for: Int.self) { groupId in
-                GroupView(groupId: groupId)
-            }
             .task {
                 await viewModel.loadGroups()
             }
-            .onChange(of: path) { _, newPath in
+            .onChange(of: appState.selectedTab) { _, newTab in
                 // Coming back from a group picks up any edit made in there.
-                if newPath.isEmpty {
+                if newTab == .groups {
                     Task { await viewModel.loadGroups() }
                 }
             }
@@ -73,7 +72,7 @@ struct GroupsView: View {
                 GroupFormSheet { groupId in
                     Task {
                         await viewModel.loadGroups()
-                        path.append(groupId)
+                        appState.openGroup(groupId)
                     }
                 }
             }
@@ -81,7 +80,7 @@ struct GroupsView: View {
                 JoinGroupSheet { group in
                     Task {
                         await viewModel.loadGroups()
-                        path.append(group.id)
+                        appState.openGroup(group.id)
                     }
                 }
             }
@@ -91,4 +90,5 @@ struct GroupsView: View {
 
 #Preview {
     GroupsView()
+        .environmentObject(AppState())
 }


### PR DESCRIPTION
Replaces the system `TabView` with a flat monochrome bar pinned to the bottom, and makes the open group a tab of its own.

## Bar

Three icons, no labels: Groups, Group, Settings. Background color, 0.5pt hairline on top, selected icon in `foreground` and the rest in `muted-foreground`. VoiceOver still reads the tab names.

It is stacked in a `VStack` rather than applied as a `safeAreaInset`. An inset is space content is invited to draw underneath, and a `List` accepts, which took the floating add-expense button behind the bar along with it. Stacked, the bar owns its space and the list ends above it.

## Group as a tab

`AppState` holds the selected tab and the open group id, persisted in `UserDefaults`, so the app reopens on the group you were last in. Tapping a card calls `openGroup(id)` instead of pushing onto a path; the Group tab shows an empty state until one is picked. Returning to Groups refetches, same as popping used to.

## Group screen

- Back is a bare `chevron.left`, Edit is a `gearshape`.
- The group name hands off to the toolbar's principal slot once it scrolls out of the list, driven by `onScrollGeometryChange`.
- The nav bar is opaque: as a material it smeared the scrolled-away action buttons behind the status bar, right above the pinned date header.
- The add button is a `safeAreaInset` on the list, so the space it reserves is what keeps the last expense row uncovered -- no hardcoded spacer row.

## Notes

- `project.pbxproj` churn is Xcode reordering two sections, no content change.
- `SettingsView` still uses a system grouped `List`, which reads gray against the rest. Left alone, out of scope here.
- Verified by `xcodebuild` only. The group screen sits behind Google sign-in, so I could not check the layout in a simulator -- the collapse threshold (52pt) and the button clearance are worth a look on device.