### PR TITLE
API: store the split mode and per-split percentages

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,13 +46,16 @@ repositories use **primary constructors** for injection — match that style.
 - `Balance` is a **pairwise, per-group** row: `(UserId, PeerId, GroupId, Amount)`. Each
   debt is stored twice, once from each side, with opposite signs.
 
-**Split mode** — "equal", "exact", "percentage" — is a **client-only** concept. The API
-accepts and stores absolute per-user amounts and nothing else, so a mode exists only for as
-long as it takes the client to turn it into numbers. Reopening an expense cannot recover how
-it was originally split, and searching the backend for the term finds nothing by design.
-This was re-examined when the expense sheet was designed and deliberately kept: the client
-infers *equal* when every stored amount matches within a cent, and *custom* otherwise.
-Persisting the mode is a follow-up, and would reverse this.
+**Split mode** is `Expense.SplitMode` — `equal`, `custom`, or `percentage` — stored on the
+row so reopening an expense recovers how it was divided instead of inferring it from the
+amounts. It is **descriptive, not authoritative**: nothing server-side derives an amount
+from it, so a percentage expense whose shares do not divide evenly is still accepted and
+the client keeps ownership of where the remainder cent lands. Per-split shares live in
+`ExpenseSplit.Percentage`, in percent units, non-null on every row of a `percentage`
+expense and null everywhere else — percentages sent under any other mode are nulled on
+write rather than refused. The column is nullable because a settlement has no mode; the
+service is what keeps it non-null for every `Type = Expense` row. Splits and mode are one
+fact, so an update sending `Splits` must send `SplitMode` too.
 
 **Expense date** is `Expense.Date`, nullable, client-supplied, and may be in the future.
 `CreatedAt` next to it is the audit timestamp — server-set, never accepted from a client.

--- a/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
+++ b/Splitty-API/Splitty.API.Tests/BalanceRecomputationTests.cs
@@ -30,6 +30,7 @@ public sealed class BalanceRecomputationTests(ApiFactory factory)
         (await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new
         {
             amount = 50m,
+            splitMode = "equal",
             splits = new[]
             {
                 new { userId = group.OwnerId, amount = 25m },

--- a/Splitty-API/Splitty.API.Tests/ExpenseDateTests.cs
+++ b/Splitty-API/Splitty.API.Tests/ExpenseDateTests.cs
@@ -91,6 +91,7 @@ public sealed class ExpenseDateTests(ApiFactory factory)
             amount = 20m,
             description = "Dinner",
             createdAt = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            splitMode = "equal",
             splits = new[]
             {
                 new { userId = group.OwnerId, amount = 10m },

--- a/Splitty-API/Splitty.API.Tests/ExpenseSplitTests.cs
+++ b/Splitty-API/Splitty.API.Tests/ExpenseSplitTests.cs
@@ -55,7 +55,7 @@ public sealed class ExpenseSplitTests
         var response = await owner.Http.PostAsync(
             $"/group/{groupId}/expenses",
             new StringContent(
-                JsonSerializer.Serialize(new { paidBy = payerId, amount = 10m, description = "Dinner" }),
+                JsonSerializer.Serialize(new { paidBy = payerId, amount = 10m, description = "Dinner", splitMode = "equal" }),
                 Encoding.UTF8,
                 "application/json"));
 
@@ -95,6 +95,7 @@ public sealed class ExpenseSplitTests
 
         var response = await owner.UpdateExpenseAsync(groupId, expenseId, new
         {
+            splitMode = "equal",
             splits = new[] { Split(payerId, 8m), Split(peerId, 8m) }
         });
 
@@ -144,6 +145,7 @@ public sealed class ExpenseSplitTests
         paidBy,
         amount,
         description = "Dinner",
+        splitMode = "equal",
         splits
     };
 

--- a/Splitty-API/Splitty.API.Tests/GroupFixture.cs
+++ b/Splitty-API/Splitty.API.Tests/GroupFixture.cs
@@ -62,7 +62,11 @@ public sealed class GroupFixture
         return new GroupFixture(factory, groupId, owner, ownerUser.Id, guest, guestUser.Id, guestUser.Token);
     }
 
-    public async Task<int> CreateExpenseAsync(decimal amount, decimal share, DateTime? date = null)
+    public async Task<int> CreateExpenseAsync(
+        decimal amount,
+        decimal share,
+        DateTime? date = null,
+        string splitMode = "equal")
     {
         var response = await Owner.CreateExpenseAsync(Id, new
         {
@@ -70,6 +74,7 @@ public sealed class GroupFixture
             amount,
             description = "Dinner",
             date,
+            splitMode,
             splits = new[]
             {
                 new { userId = OwnerId, amount = share },
@@ -113,6 +118,7 @@ public sealed class GroupFixture
             Amount = amount,
             PaidBy = OwnerId,
             Type = ExpenseType.Expense,
+            SplitMode = SplitMode.Equal,
             Splits =
             [
                 new ExpenseSplit { UserId = OwnerId, Amount = share },

--- a/Splitty-API/Splitty.API.Tests/SplitModeTests.cs
+++ b/Splitty-API/Splitty.API.Tests/SplitModeTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Splitty.Domain.Entities;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// How the user said an expense was divided, stored alongside the division itself. The
+/// mode is descriptive: nothing here re-derives an amount from a percentage, which is why
+/// a percentage expense whose shares do not divide evenly is still accepted.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class SplitModeTests(ApiFactory factory)
+{
+    [Fact]
+    public async Task A_mode_supplied_on_create_is_stored_and_returned()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m, splitMode: "custom");
+
+        Assert.Equal(SplitMode.Custom, await StoredModeAsync(expenseId));
+
+        var body = await group.Owner.ReadJsonAsync(await group.Owner.GetExpenseAsync(group.Id, expenseId));
+        Assert.Equal("custom", body.GetProperty("splitMode").GetString());
+    }
+
+    [Fact]
+    public async Task Create_rejects_a_request_that_omits_the_mode()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, new
+        {
+            paidBy = group.OwnerId,
+            amount = 20m,
+            description = "Dinner",
+            splits = new[]
+            {
+                new { userId = group.OwnerId, amount = 10m },
+                new { userId = group.GuestId, amount = 10m }
+            }
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await ErrorResponseAssertions.ReadErrorAsync(response);
+    }
+
+    [Fact]
+    public async Task A_percentage_expense_stores_a_percentage_on_every_split()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var expenseId = await CreatePercentageExpenseAsync(group, ownerPercentage: 70m, guestPercentage: 30m);
+
+        var percentages = await StoredPercentagesAsync(expenseId);
+        Assert.Equal([30m, 70m], percentages.Order());
+    }
+
+    /// <summary>
+    /// The percentages say 70/30 while the amounts are split evenly. Nothing rejects the
+    /// mismatch because the amounts are the only money truth — checking the two against
+    /// each other would put the remainder cent on the server.
+    /// </summary>
+    [Fact]
+    public async Task Percentages_are_not_checked_against_the_amounts()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, Expense(
+            group,
+            amount: 20m,
+            mode: "percentage",
+            ownerSplit: new { userId = group.OwnerId, amount = 10m, percentage = 70m },
+            guestSplit: new { userId = group.GuestId, amount = 10m, percentage = 30m }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_percentage_expense_is_rejected_when_a_split_has_no_percentage()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, Expense(
+            group,
+            amount: 20m,
+            mode: "percentage",
+            ownerSplit: new { userId = group.OwnerId, amount = 14m, percentage = 70m },
+            guestSplit: new { userId = group.GuestId, amount = 6m }));
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task A_percentage_expense_is_rejected_when_the_percentages_do_not_sum_to_100()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, Expense(
+            group,
+            amount: 20m,
+            mode: "percentage",
+            ownerSplit: new { userId = group.OwnerId, amount = 14m, percentage = 70m },
+            guestSplit: new { userId = group.GuestId, amount = 6m, percentage = 40m }));
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Percentages_sent_with_a_non_percentage_mode_are_nulled_rather_than_rejected()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+
+        var response = await group.Owner.CreateExpenseAsync(group.Id, Expense(
+            group,
+            amount: 20m,
+            mode: "equal",
+            ownerSplit: new { userId = group.OwnerId, amount = 10m, percentage = 50m },
+            guestSplit: new { userId = group.GuestId, amount = 10m, percentage = 50m }));
+
+        response.EnsureSuccessStatusCode();
+        var expenseId = (await group.Owner.ReadJsonAsync(response)).GetProperty("id").GetInt32();
+
+        Assert.All(await StoredPercentagesAsync(expenseId), Assert.Null);
+    }
+
+    [Fact]
+    public async Task Leaving_percentage_mode_nulls_the_percentages()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await CreatePercentageExpenseAsync(group, ownerPercentage: 70m, guestPercentage: 30m);
+
+        (await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new
+        {
+            splitMode = "equal",
+            splits = new[]
+            {
+                new { userId = group.OwnerId, amount = 10m, percentage = 70m },
+                new { userId = group.GuestId, amount = 10m, percentage = 30m }
+            }
+        })).EnsureSuccessStatusCode();
+
+        Assert.Equal(SplitMode.Equal, await StoredModeAsync(expenseId));
+        Assert.All(await StoredPercentagesAsync(expenseId), Assert.Null);
+    }
+
+    /// <summary>
+    /// A mode-only edit off percentage never resupplies the rows, so the percentages have
+    /// to be cleared on the rows already stored or the expense keeps shares its mode no
+    /// longer claims.
+    /// </summary>
+    [Fact]
+    public async Task A_mode_only_edit_off_percentage_nulls_the_stored_percentages()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await CreatePercentageExpenseAsync(group, ownerPercentage: 70m, guestPercentage: 30m);
+
+        (await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new { splitMode = "custom" }))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal(SplitMode.Custom, await StoredModeAsync(expenseId));
+        Assert.All(await StoredPercentagesAsync(expenseId), Assert.Null);
+    }
+
+    [Fact]
+    public async Task An_edit_sending_splits_without_a_mode_is_rejected()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        var response = await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new
+        {
+            splits = new[]
+            {
+                new { userId = group.OwnerId, amount = 10m },
+                new { userId = group.GuestId, amount = 10m }
+            }
+        });
+
+        await ErrorResponseAssertions.AssertErrorAsync(response, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task An_edit_may_change_the_mode_alone()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        var expenseId = await group.CreateExpenseAsync(amount: 20m, share: 10m);
+
+        (await group.Owner.UpdateExpenseAsync(group.Id, expenseId, new { splitMode = "custom" }))
+            .EnsureSuccessStatusCode();
+
+        Assert.Equal(SplitMode.Custom, await StoredModeAsync(expenseId));
+    }
+
+    /// <summary>
+    /// A settlement is an Expense row with no split mode, which is what makes a null mode
+    /// mean exactly one thing.
+    /// </summary>
+    [Fact]
+    public async Task A_settlement_stores_no_mode()
+    {
+        var group = await GroupFixture.CreateAsync(factory);
+        await factory.DrainProcessedAsync();
+        await group.CreateExpenseAsync(amount: 20m, share: 10m);
+        await factory.WaitForProcessedAsync();
+
+        var settlementId = await group.SettleAsync(5m);
+
+        Assert.Null(await StoredModeAsync(settlementId));
+    }
+
+    private Task<SplitMode?> StoredModeAsync(int expenseId) =>
+        factory.UseDbAsync(db => db.Expense
+            .Where(e => e.Id == expenseId)
+            .Select(e => e.SplitMode)
+            .FirstAsync());
+
+    private Task<List<decimal?>> StoredPercentagesAsync(int expenseId) =>
+        factory.UseDbAsync(db => db.ExpenseSplit
+            .Where(s => s.ExpenseId == expenseId)
+            .Select(s => s.Percentage)
+            .ToListAsync());
+
+    private async Task<int> CreatePercentageExpenseAsync(
+        GroupFixture group,
+        decimal ownerPercentage,
+        decimal guestPercentage)
+    {
+        var response = await group.Owner.CreateExpenseAsync(group.Id, Expense(
+            group,
+            amount: 20m,
+            mode: "percentage",
+            ownerSplit: new { userId = group.OwnerId, amount = 10m, percentage = ownerPercentage },
+            guestSplit: new { userId = group.GuestId, amount = 10m, percentage = guestPercentage }));
+        response.EnsureSuccessStatusCode();
+
+        return (await group.Owner.ReadJsonAsync(response)).GetProperty("id").GetInt32();
+    }
+
+    private static object Expense(
+        GroupFixture group,
+        decimal amount,
+        string mode,
+        object ownerSplit,
+        object guestSplit) => new
+    {
+        paidBy = group.OwnerId,
+        amount,
+        description = "Dinner",
+        splitMode = mode,
+        splits = new[] { ownerSplit, guestSplit }
+    };
+}

--- a/Splitty-API/Splitty.API.Tests/TransactionDrainTests.cs
+++ b/Splitty-API/Splitty.API.Tests/TransactionDrainTests.cs
@@ -44,6 +44,7 @@ public sealed class TransactionDrainTests
             paidBy = ownerUser.Id,
             amount = 20m,
             description = "Dinner",
+            splitMode = "equal",
             splits = new[]
             {
                 new { userId = ownerUser.Id, amount = 10m },

--- a/Splitty-API/Splitty.API/Controllers/GroupController.cs
+++ b/Splitty-API/Splitty.API/Controllers/GroupController.cs
@@ -211,6 +211,7 @@ public class GroupController(
             GroupId = groupId,
             PaidBy = request.PaidBy,
             Date = request.Date,
+            SplitMode = request.SplitMode,
             ExpenseSplits = request.Splits
         };
 
@@ -248,6 +249,7 @@ public class GroupController(
             Description = request.Description,
             PaidBy = request.PaidBy,
             Date = request.Date,
+            SplitMode = request.SplitMode,
             ExpenseSplits = request.Splits
         };
 

--- a/Splitty-API/Splitty.DTO/Internal/CreateExpenseDTO.cs
+++ b/Splitty-API/Splitty.DTO/Internal/CreateExpenseDTO.cs
@@ -9,6 +9,7 @@ public class CreateExpenseDTO
     public Decimal Amount { get; set; }
     public string Description { get; set; }
     public DateTime? Date { get; set; }
+    public required SplitMode SplitMode { get; set; }
     public required List<ExpenseSplitDTO> ExpenseSplits { get; set; }
 }
 
@@ -16,4 +17,7 @@ public partial class ExpenseSplitDTO
 {
     public int UserId { get; set; }
     public Decimal Amount { get; set; }
+
+    /// Percent units (70.00). Required on a percentage expense, ignored on any other.
+    public Decimal? Percentage { get; set; }
 }

--- a/Splitty-API/Splitty.DTO/Internal/UpdateExpenseDTO.cs
+++ b/Splitty-API/Splitty.DTO/Internal/UpdateExpenseDTO.cs
@@ -10,6 +10,7 @@ public class UpdateExpenseDTO
     public Decimal? Amount { get; set; }
     public string? Description { get; set; }
     public DateTime? Date { get; set; }
+    public SplitMode? SplitMode { get; set; }
     public List<UpdateExpenseSplitDTO>? ExpenseSplits { get; set; }
 }
 
@@ -18,4 +19,7 @@ public partial class UpdateExpenseSplitDTO
     public int Id { get; set; }
     public int UserId { get; set; }
     public Decimal Amount { get; set; }
+
+    /// Percent units (70.00). Required on a percentage expense, ignored on any other.
+    public Decimal? Percentage { get; set; }
 }

--- a/Splitty-API/Splitty.DTO/Request/CreateExpenseRequest.cs
+++ b/Splitty-API/Splitty.DTO/Request/CreateExpenseRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Splitty.Domain.Entities;
 using Splitty.DTO.Internal;
 
 namespace Splitty.DTO.Request;
@@ -18,6 +19,13 @@ public class CreateExpenseRequest
     /// </summary>
     public DateTime? Date { get; set; }
     
+    /// <summary>
+    /// Required for the same reason <see cref="Splits"/> is: a stored <c>null</c> then
+    /// means exactly one thing — a settlement — rather than "an expense whose client
+    /// forgot to say".
+    /// </summary>
+    public required SplitMode SplitMode { get; set; }
+
     /// <summary>
     /// Required rather than nullable so a payload omitting it is rejected by the JSON
     /// deserializer, before any handler has to treat "absent" and "empty" the same way.

--- a/Splitty-API/Splitty.DTO/Request/UpdateExpenseRequest.cs
+++ b/Splitty-API/Splitty.DTO/Request/UpdateExpenseRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Splitty.Domain.Entities;
 using Splitty.DTO.Internal;
 
 namespace Splitty.DTO.Request;
@@ -13,5 +14,12 @@ public class UpdateExpenseRequest
     
     public DateTime? Date { get; set; }
     
+    /// <summary>
+    /// Omitted means unchanged, except that an update supplying <see cref="Splits"/> must
+    /// supply this too — the rows and the mode describing them are one fact, and letting
+    /// half of it move would leave the other half lying about the rows it names.
+    /// </summary>
+    public SplitMode? SplitMode { get; set; }
+
     public List<UpdateExpenseSplitDTO>? Splits { get; set; }
 }

--- a/Splitty-API/Splitty.Domain/Entities/Expense.cs
+++ b/Splitty-API/Splitty.Domain/Entities/Expense.cs
@@ -9,6 +9,18 @@ public enum ExpenseType
     Payment
 }
 
+/// <summary>
+/// How the user said an expense should be divided. Descriptive, not authoritative: the
+/// split amounts are the only money truth and are never re-derived from the mode, so a
+/// client is free to place a remainder cent wherever it likes.
+/// </summary>
+public enum SplitMode
+{
+    Equal,
+    Custom,
+    Percentage
+}
+
 [Table("Expense")]
 public class Expense
 {
@@ -24,6 +36,13 @@ public class Expense
     public string Description { get; set; }
 
     public ExpenseType Type { get; set; } = ExpenseType.Expense;
+
+    /// <summary>
+    /// Nullable in the schema because a settlement has no split mode, but non-null for
+    /// every <see cref="ExpenseType.Expense"/> row — the service is what holds that line.
+    /// Making the column <c>NOT NULL</c> would break the settle path.
+    /// </summary>
+    public SplitMode? SplitMode { get; set; }
 
     /// <summary>
     /// When the expense happened, as the user says it did. Nullable because rows written

--- a/Splitty-API/Splitty.Domain/Entities/ExpenseSplit.cs
+++ b/Splitty-API/Splitty.Domain/Entities/ExpenseSplit.cs
@@ -14,6 +14,13 @@ public class ExpenseSplit
     public int UserId { get; init; }
     
     public Decimal Amount { get; set; }
+
+    /// <summary>
+    /// The share this row was said to be, in percent units (<c>70.00</c>). Non-null on
+    /// every row of a <see cref="SplitMode.Percentage"/> expense and null everywhere else,
+    /// including on settlements. Never used to compute <see cref="Amount"/>.
+    /// </summary>
+    public Decimal? Percentage { get; set; }
     
     [JsonIgnore]
     public Expense Expense { get; init; }

--- a/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
+++ b/Splitty-API/Splitty.Infrastructure/ApplicationDbContext.cs
@@ -132,6 +132,9 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.Amount).IsRequired().HasColumnType("decimal(18,2)");
             entity.Property(e => e.Description).HasMaxLength(500);
             entity.Property(e => e.Type).IsRequired().HasDefaultValue(Domain.Entities.ExpenseType.Expense);
+
+            // Nullable so a settlement can store no mode; see Expense.SplitMode.
+            entity.Property(e => e.SplitMode);
             entity.Property(e => e.CreatedAt).IsRequired();
             entity.Property(e => e.UpdatedAt).IsRequired();
 
@@ -150,6 +153,7 @@ public class ApplicationDbContext : DbContext
         {
             entity.HasKey(es => es.Id);
             entity.Property(es => es.Amount).IsRequired().HasColumnType("decimal(18,2)");
+            entity.Property(es => es.Percentage).HasColumnType("decimal(5,2)");
 
             entity.HasOne(es => es.Expense)
                 .WithMany(e => e.Splits)

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260824185454_Add_Split_Mode_And_Percentages.Designer.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260824185454_Add_Split_Mode_And_Percentages.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Splitty.Infrastructure;
@@ -11,9 +12,11 @@ using Splitty.Infrastructure;
 namespace Splitty.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824185454_Add_Split_Mode_And_Percentages")]
+    partial class Add_Split_Mode_And_Percentages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Splitty-API/Splitty.Infrastructure/Migrations/20260824185454_Add_Split_Mode_And_Percentages.cs
+++ b/Splitty-API/Splitty.Infrastructure/Migrations/20260824185454_Add_Split_Mode_And_Percentages.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Splitty.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Split_Mode_And_Percentages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Percentage",
+                table: "ExpenseSplit",
+                type: "numeric(5,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SplitMode",
+                table: "Expense",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Percentage",
+                table: "ExpenseSplit");
+
+            migrationBuilder.DropColumn(
+                name: "SplitMode",
+                table: "Expense");
+        }
+    }
+}

--- a/Splitty-API/Splitty.Seeder/DatabaseSeeder.cs
+++ b/Splitty-API/Splitty.Seeder/DatabaseSeeder.cs
@@ -63,6 +63,10 @@ public class DatabaseSeeder
                 // Random payer from group members
                 var payer = groupMemberships[_random.Next(groupMemberships.Count)].User;
 
+                // One percentage expense per group, so a client opening the seed data has
+                // a real percentage split to read rather than only equal ones.
+                var mode = i == 0 ? SplitMode.Percentage : SplitMode.Equal;
+
                 var expense = new Expense
                 {
                     GroupId = group.Id,
@@ -70,6 +74,7 @@ public class DatabaseSeeder
                     Amount = amount,
                     Description = GetRandomExpenseDescription(),
                     Type = ExpenseType.Expense,
+                    SplitMode = mode,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow,
                     Group = group,
@@ -79,11 +84,21 @@ public class DatabaseSeeder
                 context.SaveChanges();
 
                 var splitAmount = Math.Round(amount / groupMemberships.Count, 2);
-                var splits = groupMemberships.Select(m => new ExpenseSplit
+
+                // Amounts stay evenly divided either way: the mode describes how the split
+                // was chosen, it is never what the amounts are computed from. The last
+                // member absorbs the percentage remainder for the same reason.
+                var evenPercentage = Math.Round(100m / groupMemberships.Count, 2);
+                var splits = groupMemberships.Select((m, index) => new ExpenseSplit
                 {
                     ExpenseId = expense.Id,
                     UserId = m.UserId,
                     Amount = splitAmount,
+                    Percentage = mode == SplitMode.Percentage
+                        ? index == groupMemberships.Count - 1
+                            ? 100m - evenPercentage * (groupMemberships.Count - 1)
+                            : evenPercentage
+                        : null,
                     Expense = expense,
                     User = m.User
                 }).ToList();

--- a/Splitty-API/Splitty.Service/BalanceService.cs
+++ b/Splitty-API/Splitty.Service/BalanceService.cs
@@ -125,8 +125,9 @@ public class BalanceService(
 
         ExpenseSplitInvariants.Ensure(
             settleExpense.Type,
+            settleExpense.SplitMode,
             settleExpense.Amount,
-            settleExpense.Splits.Select(s => s.Amount));
+            settleExpense.Splits.Select(s => new SplitShape(s.Amount, s.Percentage)));
 
         await expenseRepository.CreateAsync(settleExpense);
     }
@@ -186,8 +187,9 @@ public class BalanceService(
 
         ExpenseSplitInvariants.Ensure(
             settlement.Type,
+            settlement.SplitMode,
             settlement.Amount,
-            settlement.Splits.Select(s => s.Amount));
+            settlement.Splits.Select(s => new SplitShape(s.Amount, s.Percentage)));
 
         await expenseRepository.UpdateAsync(settlement);
     }

--- a/Splitty-API/Splitty.Service/ExpenseService.cs
+++ b/Splitty-API/Splitty.Service/ExpenseService.cs
@@ -12,7 +12,16 @@ public class ExpenseService(
 {
     public async Task<Expense> CreateAsync(CreateExpenseDTO dto, int userId)
     {
-        ExpenseSplitInvariants.Ensure(ExpenseType.Expense, dto.Amount, dto.ExpenseSplits.Select(s => s.Amount));
+        // Percentages are meaningless off a percentage expense, so they are dropped rather
+        // than refused: a client that sends both a mode and leftover percentages is
+        // describing an equal split, and the stored rows should say only that.
+        var percentages = PercentagesFor(dto.SplitMode, dto.ExpenseSplits.Select(s => s.Percentage));
+
+        ExpenseSplitInvariants.Ensure(
+            ExpenseType.Expense,
+            dto.SplitMode,
+            dto.Amount,
+            dto.ExpenseSplits.Zip(percentages, (s, p) => new SplitShape(s.Amount, p)));
 
         var splits = dto.ExpenseSplits;
 
@@ -27,10 +36,12 @@ public class ExpenseService(
             GroupId = dto.GroupId,
             PaidBy = dto.PaidBy,
             Date = ExpenseDate.Normalize(dto.Date),
-            Splits = splits.Select(s => new ExpenseSplit
+            SplitMode = dto.SplitMode,
+            Splits = splits.Zip(percentages, (s, percentage) => new ExpenseSplit
             {
                 Amount = s.Amount,
                 UserId = s.UserId,
+                Percentage = percentage,
             }).ToList()
         };
 
@@ -80,6 +91,13 @@ public class ExpenseService(
     
     public async Task<Expense> UpdateAsync(UpdateExpenseDTO dto, int userId)
     {
+        // The rows and the mode naming them are one fact. Accepting new splits without a
+        // mode would leave the stored mode describing rows it has never seen.
+        if (dto.ExpenseSplits is not null && dto.SplitMode is null)
+        {
+            throw new ArgumentException("An update that changes the splits must also send the split mode.");
+        }
+
         var expense = await expenseRepository.FindByIdAsync(dto.Id);
 
         if (expense is null)
@@ -114,13 +132,28 @@ public class ExpenseService(
                 : expense.Splits.Select(s => s.UserId));
 
         var resultingAmount = dto.Amount ?? expense.Amount;
-        IEnumerable<decimal> resultingSplits = dto.ExpenseSplits is not null
-            ? dto.ExpenseSplits.Select(s => s.Amount)
-            : expense.Splits.Select(s => s.Amount);
+        var resultingMode = dto.SplitMode ?? expense.SplitMode;
 
-        ExpenseSplitInvariants.Ensure(expense.Type, resultingAmount, resultingSplits);
+        // Validate the mode against the rows it will actually name, which for a mode-only
+        // edit are the rows already stored. Leaving percentage mode nulls them here too,
+        // so an expense never carries percentages its mode does not claim.
+        var resultingAmounts = dto.ExpenseSplits is not null
+            ? dto.ExpenseSplits.Select(s => s.Amount).ToList()
+            : expense.Splits.Select(s => s.Amount).ToList();
+        var resultingPercentages = PercentagesFor(
+            resultingMode,
+            dto.ExpenseSplits is not null
+                ? dto.ExpenseSplits.Select(s => s.Percentage)
+                : expense.Splits.Select(s => s.Percentage));
+
+        ExpenseSplitInvariants.Ensure(
+            expense.Type,
+            resultingMode,
+            resultingAmount,
+            resultingAmounts.Zip(resultingPercentages, (amount, percentage) => new SplitShape(amount, percentage)));
 
         expense.Amount = resultingAmount;
+        expense.SplitMode = resultingMode;
         expense.Description = dto.Description ?? expense.Description;
         expense.PaidBy = dto.PaidBy ?? expense.PaidBy;
         expense.Date = ExpenseDate.Normalize(dto.Date) ?? expense.Date;
@@ -128,17 +161,36 @@ public class ExpenseService(
         
         if (dto.ExpenseSplits is not null)
         {
-            expense.Splits = dto.ExpenseSplits.Select(s => new ExpenseSplit
+            expense.Splits = dto.ExpenseSplits.Zip(resultingPercentages, (s, percentage) => new ExpenseSplit
             {
                 Id = s.Id,
                 Amount = s.Amount,
                 UserId = s.UserId,
+                Percentage = percentage,
             }).ToList();
+        }
+        else
+        {
+            foreach (var (split, percentage) in expense.Splits.Zip(resultingPercentages))
+            {
+                split.Percentage = percentage;
+            }
         }
         
         await expenseRepository.UpdateAsync(expense);
         return expense;
     }
+
+    /// <summary>
+    /// The percentage each split row should store under <paramref name="mode"/>: what was
+    /// supplied when the mode is <see cref="SplitMode.Percentage"/>, and <c>null</c>
+    /// otherwise. Nulling rather than rejecting is what lets a client switch an expense
+    /// back to an equal split without first stripping the fields it no longer means.
+    /// </summary>
+    private static List<decimal?> PercentagesFor(SplitMode? mode, IEnumerable<decimal?> supplied) =>
+        mode is SplitMode.Percentage
+            ? supplied.ToList()
+            : supplied.Select(_ => (decimal?)null).ToList();
 
     /// The expense must belong to the group the request was made against, otherwise a
     /// member of group A could read or delete an expense of group B.

--- a/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
+++ b/Splitty-API/Splitty.Service/ExpenseSplitInvariants.cs
@@ -3,6 +3,13 @@ using Splitty.Domain.Entities;
 namespace Splitty.Service;
 
 /// <summary>
+/// One split row as the invariants read it: the money, and the percentage the user said
+/// that money was. The two travel together because the percentage rules are scoped by the
+/// expense's mode and have to be checked against the same rows the amounts are.
+/// </summary>
+internal readonly record struct SplitShape(decimal Amount, decimal? Percentage);
+
+/// <summary>
 /// The split shape each expense type is allowed to have. Scoped by type because the two
 /// types are built from opposite directions: an <see cref="ExpenseType.Expense"/> carries
 /// client-supplied splits and is validated as input, while an <see cref="ExpenseType.Payment"/>
@@ -10,22 +17,26 @@ namespace Splitty.Service;
 /// </summary>
 internal static class ExpenseSplitInvariants
 {
-    public static void Ensure(ExpenseType type, decimal amount, IEnumerable<decimal>? splitAmounts)
+    public static void Ensure(
+        ExpenseType type,
+        SplitMode? mode,
+        decimal amount,
+        IEnumerable<SplitShape>? splitShapes)
     {
-        var splits = splitAmounts?.ToList();
+        var splits = splitShapes?.ToList();
 
         switch (type)
         {
             case ExpenseType.Expense:
-                EnsureExpense(amount, splits);
+                EnsureExpense(mode, amount, splits);
                 break;
             case ExpenseType.Payment:
-                EnsurePayment(amount, splits);
+                EnsurePayment(mode, amount, splits);
                 break;
         }
     }
 
-    private static void EnsureExpense(decimal amount, List<decimal>? splits)
+    private static void EnsureExpense(SplitMode? mode, decimal amount, List<SplitShape>? splits)
     {
         if (splits is null || splits.Count == 0)
         {
@@ -37,14 +48,37 @@ internal static class ExpenseSplitInvariants
             throw new ArgumentException("Expense amount must be greater than zero.");
         }
 
-        if (splits.Any(split => split <= 0))
+        if (splits.Any(split => split.Amount <= 0))
         {
             throw new ArgumentException("Expense splits must be greater than zero.");
         }
 
-        if (splits.Sum() != amount)
+        if (splits.Sum(split => split.Amount) != amount)
         {
             throw new ArgumentException("Expense splits must sum to the total.");
+        }
+
+        if (mode is null)
+        {
+            throw new ArgumentException("An expense must have a split mode.");
+        }
+
+        // Deliberately not checked against the amounts. The mode says how the user divided
+        // the bill, not what the division has to come out to: re-deriving amounts from
+        // percentages here would move the remainder cent onto the server and break every
+        // client that already placed it.
+        if (mode is SplitMode.Percentage)
+        {
+            if (splits.Any(split => split.Percentage is null))
+            {
+                throw new ArgumentException(
+                    "A percentage expense must have a percentage on every split.");
+            }
+
+            if (splits.Sum(split => split.Percentage!.Value) != 100m)
+            {
+                throw new ArgumentException("Expense split percentages must sum to 100.");
+            }
         }
     }
 
@@ -56,11 +90,16 @@ internal static class ExpenseSplitInvariants
     /// reads <c>Amount</c>. Violating this means the settle path built the expense wrong,
     /// which is why it throws rather than reporting a validation failure.
     /// </summary>
-    private static void EnsurePayment(decimal amount, List<decimal>? splits)
+    private static void EnsurePayment(SplitMode? mode, decimal amount, List<SplitShape>? splits)
     {
         if (splits is null || splits.Count != 2)
         {
             throw new InvalidOperationException("A payment must have exactly two splits.");
+        }
+
+        if (mode is not null)
+        {
+            throw new InvalidOperationException("A payment must not have a split mode.");
         }
 
         if (amount <= 0)
@@ -68,13 +107,13 @@ internal static class ExpenseSplitInvariants
             throw new InvalidOperationException("A payment's amount must be greater than zero.");
         }
 
-        if (splits[0] + splits[1] != 0)
+        if (splits[0].Amount + splits[1].Amount != 0)
         {
             throw new InvalidOperationException(
                 "A payment's splits must be equal in magnitude and opposite in sign.");
         }
 
-        if (Math.Abs(splits[0]) != amount)
+        if (Math.Abs(splits[0].Amount) != amount)
         {
             throw new InvalidOperationException(
                 "A payment's splits must match its amount.");


### PR DESCRIPTION
Closes #37. Backend half of #31; the iOS half depends on this shipping first.

## Schema

`Expense.SplitMode` — `equal | custom | percentage`, serialized snake_case by the global
converter. `ExpenseSplit.Percentage` — nullable `decimal(5,2)`, percent units. Both on the
entities, so responses carry them without a response DTO.

The mode column is nullable because a settlement stores `null`; the service is what keeps it
non-null for every `Type = Expense` row. Migration `20260824185454_Add_Split_Mode_And_Percentages`,
no backfill — the database is reseeded.

## Requests

`CreateExpenseRequest.SplitMode` is `required`, like `Splits` already was, so a stored `null`
means exactly one thing. `UpdateExpenseRequest.SplitMode` is optional-means-unchanged, except
that an update sending `Splits` must send `SplitMode` too — the rows and the mode naming them
are one fact. `ExpenseSplitDTO` and `UpdateExpenseSplitDTO` gain `Percentage?`.

## Invariants

`ExpenseSplitInvariants.Ensure` now takes the mode and a `SplitShape(Amount, Percentage)` per
row. Added alongside the existing rules, all of which are untouched:

1. An expense has a mode.
2. A `percentage` expense has a non-null percentage on every split row.
3. Those percentages sum to exactly 100.
4. `EnsurePayment` rejects a non-null mode.

The mode is never checked against the amounts. Doing so would move the remainder-cent rule
server-side, and every client that already placed it would start failing.

Percentages on a non-percentage expense are nulled on write rather than rejected — on create,
on a split rebuild, and on a mode-only edit, where the stored rows are cleared in place
because they are never resupplied.

## Seeder

One `percentage` expense per group so the client has something real to open; the rest `equal`,
settlements `null`. Amounts stay evenly divided either way, since the mode is not what they
are computed from.

## Tests

`SplitModeTests` — 11 cases covering storage and round-trip, a missing mode, percentages
stored, percentages deliberately not matching the amounts, a missing percentage, a sum that is
not 100, nulling on both write paths, splits without a mode, a mode-only edit, and a settlement
storing none. Existing tests updated to send the now-required mode. 78/78 green.

## Notes

- `CONTEXT.md`'s "split mode is a client-only concept" paragraph documented exactly what this
  reverses, so it is rewritten here.
- A mode-only edit *into* `percentage` is rejected by invariant 2, since the stored rows have
  no percentages yet. Correct, but it means the iOS half must send splits when switching into
  percentage mode.

## Out of scope

No re-derivation of amounts from percentages; amounts arrive from the client and remain the
only money truth, and the balance replay is untouched. No response DTOs for expenses.