### PR TITLE
Press feedback, haptics, and a two-step expense sheet

### DIFF
--- a/Splitty/Splitty/Components/BottomBar.swift
+++ b/Splitty/Splitty/Components/BottomBar.swift
@@ -29,6 +29,9 @@ struct BottomBar: View {
             }
             .ignoresSafeArea(edges: .bottom)
         }
+        // Selection, not impact: moving between tabs is a picker landing on a detent, and
+        // the system has a texture for exactly that.
+        .sensoryFeedback(.selection, trigger: selection)
     }
 }
 
@@ -46,7 +49,7 @@ private struct BottomBarItem: View {
                 .frame(height: 28)
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressable(scale: 0.88))
         .accessibilityLabel(tab.title)
         .animation(.easeOut(duration: 0.15), value: isSelected)
     }

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -119,6 +119,13 @@ private struct KeypadKeyStyle: ButtonStyle {
             }
             .contentShape(Rectangle())
             .animation(.easeOut(duration: configuration.isPressed ? 0.08 : 0.2), value: configuration.isPressed)
+            // On the press, with the halo, not on the release: the tap is the causal event
+            // and the two senses have to land on the same frame. Soft and half intensity —
+            // this fires several times per amount, and a full impact per digit is a drum.
+            .sensoryFeedback(
+                .impact(flexibility: .soft, intensity: 0.4),
+                trigger: configuration.isPressed
+            ) { _, isPressed in isPressed }
     }
 }
 

--- a/Splitty/Splitty/Components/ExpenseKeypad.swift
+++ b/Splitty/Splitty/Components/ExpenseKeypad.swift
@@ -7,11 +7,15 @@ import SwiftUI
 import UIKit
 
 /// Everything the pad can send back to the amount field.
+///
+/// Digits and nothing else. The pad used to carry the screen's forward action in a row
+/// above the keys, which made it the one control that had to outlive the surface it sat
+/// on; the amount screen owns that button now, where it can be the shape a primary action
+/// should be.
 enum KeypadKey: Equatable {
     case digit(Int)
     case decimalPoint
     case backspace
-    case next
 }
 
 // MARK: - The pad
@@ -22,59 +26,27 @@ enum KeypadKey: Equatable {
 /// Digits only. The arithmetic keys are gone: they turned a two-tap amount into a mode the
 /// user had to reason about, and the expression model still resolves whatever is typed.
 struct ExpenseKeypad: View {
-    let isNextEnabled: Bool
-    var isSaving: Bool = false
-    /// The digits hide while the system keyboard is up; the action row stays, so the
-    /// forward arrow keeps its place instead of moving to the other end of the sheet. The
-    /// grid keeps its space either way — collapsing it moved the arrow down at the same
-    /// moment the keyboard moved it up.
-    var showsDigits: Bool = true
     let onKey: (KeypadKey) -> Void
 
     private let digitRows = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
     var body: some View {
         VStack(spacing: 2) {
-            actionRow
-
-            VStack(spacing: 2) {
-                ForEach(digitRows, id: \.first) { row in
-                    HStack(spacing: 0) {
-                        ForEach(row, id: \.self) { digit in
-                            key(title: "\(digit)") { onKey(.digit(digit)) }
-                        }
+            ForEach(digitRows, id: \.first) { row in
+                HStack(spacing: 0) {
+                    ForEach(row, id: \.self) { digit in
+                        key(title: "\(digit)") { onKey(.digit(digit)) }
                     }
                 }
-
-                HStack(spacing: 0) {
-                    key(title: ".") { onKey(.decimalPoint) }
-                    key(title: "0") { onKey(.digit(0)) }
-                    key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
-                }
             }
-            .opacity(showsDigits ? 1 : 0)
-            .allowsHitTesting(showsDigits)
+
+            HStack(spacing: 0) {
+                key(title: ".") { onKey(.decimalPoint) }
+                key(title: "0") { onKey(.digit(0)) }
+                key(systemImage: "chevron.left", label: "delete") { onKey(.backspace) }
+            }
         }
         .padding(.bottom, 8)
-    }
-
-    /// The pad's only non-digit: the forward action, over the column it belongs to.
-    private var actionRow: some View {
-        HStack(spacing: 12) {
-            Spacer(minLength: 0)
-
-            if isSaving {
-                ProgressView()
-                    .frame(width: 44, height: 44)
-            } else {
-                ForwardButton(isEnabled: isNextEnabled) { onKey(.next) }
-                    .accessibilityLabel("next")
-                    .accessibilityIdentifier("keypad.next")
-            }
-        }
-        .frame(height: 60)
-        .padding(.leading, 8)
-        .padding(.trailing, 12)
     }
 
     private func key(

--- a/Splitty/Splitty/Components/GroupCard.swift
+++ b/Splitty/Splitty/Components/GroupCard.swift
@@ -51,6 +51,9 @@ struct GroupCard: View {
         // Shallow: the card is the width of the screen, so a small percentage is a lot of
         // travel at its edges.
         .buttonStyle(.pressable(scale: 0.98))
+        // Shared across every card on purpose: a test wants "a group", not a particular
+        // one, and naming them individually would tie it to whatever the data happens to be.
+        .accessibilityIdentifier("groups.card")
     }
 }
 

--- a/Splitty/Splitty/Components/GroupCard.swift
+++ b/Splitty/Splitty/Components/GroupCard.swift
@@ -48,7 +48,9 @@ struct GroupCard: View {
             .cornerRadius(10)
             .padding(.horizontal, 20)
         }
-        .buttonStyle(PlainButtonStyle())
+        // Shallow: the card is the width of the screen, so a small percentage is a lot of
+        // travel at its edges.
+        .buttonStyle(.pressable(scale: 0.98))
     }
 }
 

--- a/Splitty/Splitty/Components/PressableButtonStyle.swift
+++ b/Splitty/Splitty/Components/PressableButtonStyle.swift
@@ -1,0 +1,40 @@
+//
+//  PressableButtonStyle.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// The app's press feedback, in one place.
+///
+/// `.plain` draws a button with no state at all, so a card, a pill and the add button all
+/// sat inert until the finger lifted and the screen changed. Feedback belongs on the press,
+/// not on the release: the label dips the moment it is touched and comes back slower than
+/// it went down, which is what reads as a physical thing being pushed.
+///
+/// Smaller controls take a deeper dip — a 4% scale on a 56pt disc is a few points of travel
+/// and barely registers, while the same 4% across a full-width card is plenty.
+struct PressableButtonStyle: ButtonStyle {
+    var scale: CGFloat = 0.97
+    var pressedOpacity: Double = 0.9
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? scale : 1)
+            .opacity(configuration.isPressed ? pressedOpacity : 1)
+            // In fast, out slow: the press should feel instant and the release should feel
+            // like the control settling back rather than snapping.
+            .animation(
+                .easeOut(duration: configuration.isPressed ? 0.1 : 0.2),
+                value: configuration.isPressed
+            )
+    }
+}
+
+extension ButtonStyle where Self == PressableButtonStyle {
+    static var pressable: PressableButtonStyle { PressableButtonStyle() }
+
+    static func pressable(scale: CGFloat) -> PressableButtonStyle {
+        PressableButtonStyle(scale: scale)
+    }
+}

--- a/Splitty/Splitty/Components/PrimaryButton.swift
+++ b/Splitty/Splitty/Components/PrimaryButton.swift
@@ -1,0 +1,57 @@
+//
+//  PrimaryButton.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// The one commit on a screen, shaped like the system's own.
+///
+/// A full-width capsule rather than the small floating disc this replaces. A primary action
+/// should be the most obvious thing on the screen and should say what it does — a 44pt
+/// arrow parked in a corner was neither, and being small and floating is what let it end up
+/// somewhere it did not belong.
+struct PrimaryButton: View {
+    let title: String
+    var isLoading: Bool = false
+    let action: () -> Void
+
+    /// Read from the environment so `.disabled(_:)` applied by the caller styles the button
+    /// as well as blocking it — a control that looks live and does nothing is worse than
+    /// one that reads as unavailable.
+    @Environment(\.isEnabled) private var isEnabled
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                if isLoading {
+                    ProgressView()
+                        .tint(Color.expenseBackground)
+                } else {
+                    Text(title)
+                        .font(.headline)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 52)
+            .foregroundStyle(Color.expenseBackground)
+            .background(
+                Color.expenseAccent.opacity(isEnabled ? 1 : 0.3),
+                in: Capsule()
+            )
+        }
+        .buttonStyle(.pressable(scale: 0.97))
+        .animation(.easeOut(duration: 0.2), value: isEnabled)
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        PrimaryButton(title: "Next") {}
+        PrimaryButton(title: "Save") {}
+            .disabled(true)
+        PrimaryButton(title: "Save", isLoading: true) {}
+    }
+    .padding(20)
+    .background(Color.expenseBackground)
+}

--- a/Splitty/Splitty/Components/SwipeToDeleteRow.swift
+++ b/Splitty/Splitty/Components/SwipeToDeleteRow.swift
@@ -15,9 +15,14 @@ struct SwipeToDeleteRow<Content: View>: View {
     let onDelete: () -> Void
     @ViewBuilder var content: Content
 
-    @State private var offset: CGFloat = 0
+    /// Where the finger has the row. Plain `@State`, not `@GestureState`: the gesture state
+    /// resets itself the instant the drag ends, which took the row home in a single frame
+    /// with nothing to animate. Owning the value means the release is ours to spring.
+    @State private var dragOffset: CGFloat = 0
     @State private var isSwiping = false
-    @GestureState private var translation: CGFloat = 0
+    /// Bumped when a release commits, so the haptic fires with the decision rather than
+    /// with the alert that reports it.
+    @State private var commitCount = 0
 
     private static var actionWidth: CGFloat { 88 }
     /// Past this, releasing asks. Short of it the row snaps back and nothing happens.
@@ -54,24 +59,25 @@ struct SwipeToDeleteRow<Content: View>: View {
                 .offset(x: shownOffset)
         }
         .clipped()
-        .animation(.snappy(duration: 0.25), value: offset)
+        .sensoryFeedback(.impact(flexibility: .rigid), trigger: commitCount)
         // Simultaneous, not exclusive: a plain `.gesture` loses the drag to the list's own
         // pan recogniser, which is why the row stopped swiping at all. Both see the drag,
         // and the horizontal-dominance check below is what keeps a scroll a scroll.
         .simultaneousGesture(
             DragGesture(minimumDistance: 18)
-                .updating($translation) { value, state, _ in
-                    // Vertical intent belongs to the list, so only the horizontal part of a
-                    // drag that is mostly horizontal is taken.
-                    guard abs(value.translation.width) > abs(value.translation.height) else {
-                        return
-                    }
-                    state = value.translation.width
-                }
                 .onChanged { value in
-                    if abs(value.translation.width) > abs(value.translation.height) {
+                    // Direction is decided once, on the first move past the threshold, and
+                    // then held for the rest of the drag. Re-deciding every frame let a
+                    // curving finger hand the row back to the list mid-swipe.
+                    if !isSwiping {
+                        guard abs(value.translation.width) > abs(value.translation.height) else {
+                            return
+                        }
                         isSwiping = true
                     }
+                    // No animation here on purpose: while the finger is down the row is
+                    // glued to it, and the only motion is the one the hand is making.
+                    dragOffset = value.translation.width
                 }
                 .onEnded { value in
                     settle(value)
@@ -87,7 +93,7 @@ struct SwipeToDeleteRow<Content: View>: View {
     /// Clamped: the row opens to the action's width and resists past it, and never drags
     /// right of its resting place.
     private var shownOffset: CGFloat {
-        let raw = offset + translation
+        let raw = dragOffset
         if raw > 0 { return 0 }
         return raw < -Self.actionWidth
             ? -Self.actionWidth + (raw + Self.actionWidth) / 3
@@ -96,19 +102,33 @@ struct SwipeToDeleteRow<Content: View>: View {
 
     /// The row does not stay open. Releasing past the threshold asks the question and
     /// closes; the drag is the gesture, and the alert is where the decision is made.
+    ///
+    /// The threshold is applied to where the flick is *going*, not to where the finger
+    /// happened to stop. A fast short swipe is a swipe — judging it on final position alone
+    /// meant a flick that never travelled 44pt did nothing at all.
     private func settle(_ value: DragGesture.Value) {
-        guard abs(value.translation.width) > abs(value.translation.height) else { return }
+        guard isSwiping else { return }
 
-        let travelled = offset + value.translation.width
-        offset = 0
+        let projected = value.predictedEndTranslation.width
+        let committed = projected < -Self.commitWidth
 
-        if travelled < -Self.commitWidth {
+        // Bounce, and only here: the row is coming home off a throw, and the overshoot is
+        // the momentum the hand put into it. Nothing else in the row animates with bounce.
+        withAnimation(.snappy(duration: 0.3, extraBounce: 0.1)) {
+            dragOffset = 0
+        }
+
+        if committed {
+            commitCount += 1
             onDelete()
         }
     }
 
     private func delete() {
-        offset = 0
+        withAnimation(.snappy(duration: 0.3, extraBounce: 0.1)) {
+            dragOffset = 0
+        }
+        commitCount += 1
         onDelete()
     }
 }

--- a/Splitty/Splitty/Views/ExpenseDetailsStep.swift
+++ b/Splitty/Splitty/Views/ExpenseDetailsStep.swift
@@ -1,0 +1,157 @@
+//
+//  ExpenseDetailsStep.swift
+//  Splitty
+//
+
+import SwiftUI
+
+/// The second step: what the money was for, who it splits between, and when.
+///
+/// Its own view rather than a property on the sheet, because focus is scoped to the view
+/// that declares it. A `@FocusState` on the presenting screen does not reach a field inside
+/// a `navigationDestination` — the pushed screen is a separate focus scope, and a binding
+/// handed across that boundary silently does nothing.
+struct ExpenseDetailsStep: View {
+    @ObservedObject var viewModel: ExpenseFormViewModel
+    let onSave: () -> Void
+
+    @FocusState private var descriptionFocused: Bool
+    @State private var showingDatePicker = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                descriptionRow
+                splitRow
+                dateRow
+
+                if let message = viewModel.blockingMessage {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+                        .padding(.top, 4)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 4)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .scrollDismissesKeyboard(.interactively)
+        .background(Color.expenseBackground)
+        // Save rides above the keyboard because SwiftUI's own avoidance puts it there. This
+        // screen does not opt out of that, so there is nothing left to measure.
+        .safeAreaInset(edge: .bottom) {
+            PrimaryButton(title: "Save", isLoading: viewModel.isSaving, action: onSave)
+                .disabled(!viewModel.canSave)
+                .accessibilityIdentifier("expense.save")
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 12)
+                .background(Color.expenseBackground)
+        }
+        .navigationTitle(Money.formatted(cents: viewModel.totalCents))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.expenseBackground, for: .navigationBar)
+        // The field is the whole point of arriving here, so it is already waiting. Asked for
+        // after the push rather than during it: a focus request made while the transition is
+        // still running is one SwiftUI drops.
+        .task {
+            try? await Task.sleep(for: .milliseconds(400))
+            descriptionFocused = true
+        }
+        .sheet(isPresented: $showingDatePicker) {
+            ExpenseDatePicker(date: $viewModel.date)
+        }
+    }
+
+    // MARK: - Rows
+
+    private var descriptionRow: some View {
+        HStack(spacing: 14) {
+            rowIcon("text.alignleft")
+
+            TextField("What was it for?", text: $viewModel.description)
+                .focused($descriptionFocused)
+                .submitLabel(.done)
+                .foregroundStyle(Color.expenseForeground)
+                .accessibilityIdentifier("expense.description")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var splitRow: some View {
+        NavigationLink {
+            SplitConfigurationView(viewModel: viewModel)
+        } label: {
+            HStack(spacing: 14) {
+                rowIcon("person.2")
+
+                Text(viewModel.splitSummary)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.expenseForeground)
+                    .multilineTextAlignment(.leading)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.pressable(scale: 0.98))
+        .accessibilityIdentifier("expense.split")
+    }
+
+    private var dateRow: some View {
+        Button {
+            descriptionFocused = false
+            showingDatePicker = true
+        } label: {
+            HStack(spacing: 14) {
+                rowIcon("calendar")
+
+                Text(dateLabel)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.expenseForeground)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.pressable(scale: 0.98))
+        .accessibilityIdentifier("expense.date")
+    }
+
+    private func rowIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 16))
+            .foregroundStyle(.secondary)
+            .frame(width: 24)
+    }
+
+    private var dateLabel: String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(viewModel.date) { return "Today" }
+        if calendar.isDateInYesterday(viewModel.date) { return "Yesterday" }
+        return viewModel.date.formatted(.dateTime.day().month(.abbreviated).year())
+    }
+}

--- a/Splitty/Splitty/Views/ExpenseSheet.swift
+++ b/Splitty/Splitty/Views/ExpenseSheet.swift
@@ -4,17 +4,25 @@
 //
 
 import SwiftUI
-import UIKit
 
-/// Creates or edits an expense. The sheet opens on the amount, with the pad up; everything
-/// else is one row below it.
+/// Creates or edits an expense, in two steps: the amount, then everything about it.
+///
+/// One screen, one input surface. The amount screen belongs to the pad and the details
+/// screen belongs to the system keyboard, and because they are different screens the two
+/// can never contend for the bottom of the sheet. Everything that used to be needed to
+/// arbitrate between them — reserved gaps, reconstructed keyboard heights, a forward button
+/// that had to survive both — stopped being needed when the contention did.
+///
+/// It is also how money apps are shaped: the amount is a decision worth its own screen, and
+/// what the money was for is a different decision.
 struct ExpenseSheet: View {
     @StateObject private var viewModel: ExpenseFormViewModel
     @Environment(\.dismiss) private var dismiss
 
-    @FocusState private var descriptionFocused: Bool
-    @State private var showingDatePicker = false
-    @State private var keyboardInset: CGFloat = 0
+    @State private var showingDetails = false
+    /// Bumped once the server has the expense, so the success texture fires on the save
+    /// landing rather than on the tap that asked for it.
+    @State private var savedCount = 0
 
     private let onSaved: (Expense) -> Void
 
@@ -36,240 +44,64 @@ struct ExpenseSheet: View {
 
     var body: some View {
         NavigationStack {
-            ZStack(alignment: .bottom) {
-                VStack(spacing: 24) {
-                    headerRow
-
-                    Spacer(minLength: 12)
-
-                    amountRow
-
-                    Spacer(minLength: 12)
-
-                    descriptionRow
-                    splitRow
-
-                    if let message = viewModel.blockingMessage {
-                        Text(message)
-                            .font(.subheadline)
-                            .foregroundStyle(.orange)
-                    }
-
-                    if let errorMessage = viewModel.errorMessage {
-                        Text(errorMessage)
-                            .font(.subheadline)
-                            .foregroundStyle(.red)
-                            .multilineTextAlignment(.center)
-                    }
-
-                    // Held open whether the pad is showing its digits or not, so opening
-                    // the keyboard moves nothing above it.
-                    Color.clear.frame(height: bottomReserve)
+            amountStep
+                .navigationDestination(isPresented: $showingDetails) {
+                    ExpenseDetailsStep(viewModel: viewModel, onSave: save)
                 }
-                // The content above the pad is anchored to the sheet, not to the keyboard:
-                // letting the system lift it as well produced two shifts at once.
-                .ignoresSafeArea(.keyboard, edges: .bottom)
-
-                // The pad is content, not a keyboard. As a keyboard it dismissed on its
-                // own clock, sliding out from under a sheet that was still on screen;
-                // owned by the sheet it simply travels with it. Its action row survives
-                // the system keyboard and rides above it, so the arrow stays put.
-                ExpenseKeypad(
-                    isNextEnabled: isNextEnabled,
-                    isSaving: viewModel.isSaving,
-                    showsDigits: !descriptionFocused,
-                    onKey: handle(key:)
-                )
-                .padding(.bottom, padBottomInset)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 12)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            // The keyboard is answered by hand, below: letting SwiftUI lift the sheet moved
-            // the pad outside the bounds it is hit-tested against, so the arrow drew in the
-            // right place and answered to nothing.
-            .ignoresSafeArea(.keyboard, edges: .bottom)
-            // The same colour the pad paints itself, so the two meet without a seam.
-            .background(Color.expenseBackground)
-            // No bar: the sheet's own header carries what it needs, and an empty bar over
-            // the amount was only there to hold buttons that are gone.
-            .toolbar(.hidden, for: .navigationBar)
-            .presentationCornerRadius(28)
-            .presentationBackground(Color.expenseBackground)
-            .onReceive(NotificationCenter.default.publisher(
-                for: UIResponder.keyboardWillChangeFrameNotification
-            )) { note in
-                setKeyboardInset(from: note)
-            }
-            .onReceive(NotificationCenter.default.publisher(
-                for: UIResponder.keyboardWillHideNotification
-            )) { _ in
-                withAnimation(.easeOut(duration: 0.25)) { keyboardInset = 0 }
-            }
-            .sheet(isPresented: $showingDatePicker) {
-                ExpenseDatePicker(date: $viewModel.date)
-            }
         }
+        .presentationCornerRadius(28)
+        .presentationBackground(Color.expenseBackground)
+        .sensoryFeedback(.success, trigger: savedCount)
     }
 
-    // MARK: - Rows
+    // MARK: - Step one: the amount
 
-    /// The date, and nothing else: the forward action stays with the pad at the bottom of
-    /// the sheet whether the pad or the keyboard is up.
-    private var headerRow: some View {
-        HStack {
-            dateButton
-            Spacer()
+    /// Nothing but the number and the keys that change it.
+    ///
+    /// `Spacer`s are safe here in a way they were not before: this screen has no keyboard,
+    /// so the box the amount centres in never changes size and the number never moves.
+    private var amountStep: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            AmountDisplay(text: viewModel.amount.displayText)
+                .frame(maxWidth: .infinity)
+                .accessibilityIdentifier("expense.amount")
+
+            Spacer(minLength: 0)
+
+            PrimaryButton(title: "Next") {
+                showingDetails = true
+            }
+            .disabled(viewModel.totalCents == 0)
+            .accessibilityIdentifier("expense.next")
+            .padding(.horizontal, 20)
+            .padding(.bottom, 16)
+
+            ExpenseKeypad(onKey: handle(key:))
         }
-        .padding(.horizontal, 8)
-    }
-
-    @ViewBuilder
-    private var dateButton: some View {
-        if #available(iOS 26.0, *) {
-            Button {
-                showingDatePicker = true
-            } label: {
-                Text(dateLabel)
-                    .font(.subheadline.weight(.medium))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.expenseBackground)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color.expenseBackground, for: .navigationBar)
+        .toolbar {
+            // The way out. A sheet with no visible dismiss leaves the drag gesture as the
+            // only exit, which is not something to have to discover.
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
                     .foregroundStyle(Color.expenseForeground)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .glassEffect(.regular, in: .capsule)
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("expense.date")
-        } else {
-            Button {
-                showingDatePicker = true
-            } label: {
-                Text(dateLabel)
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(Color.expenseForeground)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(Color.expenseForeground.opacity(0.07), in: Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("expense.date")
-        }
-    }
-
-    private var dateLabel: String {
-        let calendar = Calendar.current
-        if calendar.isDateInToday(viewModel.date) { return "Today" }
-        if calendar.isDateInYesterday(viewModel.date) { return "Yesterday" }
-        return viewModel.date.formatted(.dateTime.day().month(.abbreviated).year())
-    }
-
-    /// Tapping the number puts the pad back, whichever field had focus.
-    private var amountRow: some View {
-        AmountDisplay(text: viewModel.amount.displayText)
-            .frame(maxWidth: .infinity)
-            .contentShape(Rectangle())
-            .onTapGesture { descriptionFocused = false }
-            .accessibilityIdentifier("expense.amount")
-    }
-
-    private var descriptionRow: some View {
-        HStack(spacing: 14) {
-            Image(systemName: "text.alignleft")
-                .font(.system(size: 18))
-                .foregroundStyle(.secondary)
-                .frame(width: 48, height: 48)
-                .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
-
-            VStack(alignment: .leading, spacing: 2) {
-                TextField("What was it for?", text: $viewModel.description)
-                    .focused($descriptionFocused)
-                    .submitLabel(.done)
-                    .foregroundStyle(Color.expenseForeground)
-                    .accessibilityIdentifier("expense.description")
-                    .frame(height: 30)
+                    .accessibilityIdentifier("expense.cancel")
             }
         }
-        .padding(.horizontal, 8)
-    }
-
-    private var splitRow: some View {
-        NavigationLink {
-            SplitConfigurationView(viewModel: viewModel)
-        } label: {
-            HStack {
-                Text(viewModel.splitSummary)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.expenseForeground)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(Color.expenseForeground.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
-            .padding(.horizontal, 8)
-        }
-        .accessibilityIdentifier("expense.split")
     }
 
     // MARK: - Behaviour
-
-    /// One action row and four digit rows, plus the padding under them. Reserved in the
-    /// layout at all times: the pad shrinks to the action row when the keyboard takes over,
-    /// and nothing above it is allowed to notice.
-    private static let actionRowHeight: CGFloat = 60
-    private static let digitsHeight: CGFloat = 4 * 68 + 2 * 3
-    private static let padHeight: CGFloat = actionRowHeight + digitsHeight + 8
-
-    /// What the rows above have to keep clear. The pad's own height while the pad is up;
-    /// while the keyboard is up it is the keyboard plus the action row riding on it, which
-    /// is taller — so the description and the split move up towards the amount rather than
-    /// letting the arrow land on top of them.
-    private var bottomReserve: CGFloat {
-        guard descriptionFocused else { return Self.padHeight }
-        return keyboardInset + Self.actionRowHeight + 24
-    }
-
-    /// The keyboard covers the digit grid, which is hidden under it anyway, so only the
-    /// part of it that reaches past the grid moves the pad. Ignored unless the description
-    /// is what the keyboard belongs to: the split screen raises one of its own, and acting
-    /// on that left the pad hoisted over the sheet on the way back.
-    private var padBottomInset: CGFloat {
-        guard descriptionFocused else { return 0 }
-        return max(0, keyboardInset - Self.digitsHeight)
-    }
-
-    /// How far the keyboard reaches into the sheet, past the home indicator the sheet
-    /// already clears.
-    private func setKeyboardInset(from note: Notification) {
-        guard let frame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              let window = UIApplication.shared.connectedScenes
-                  .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
-                  .first
-        else { return }
-
-        let overlap = max(0, window.bounds.maxY - frame.minY - window.safeAreaInsets.bottom)
-        withAnimation(.easeOut(duration: 0.25)) { keyboardInset = overlap }
-    }
-
-    /// One arrow, two jobs: leaving the amount only needs an amount, but once the
-    /// description has focus the arrow is the save and answers to the whole sheet.
-    private var isNextEnabled: Bool {
-        descriptionFocused ? viewModel.canSave : viewModel.totalCents > 0
-    }
 
     private func handle(key: KeypadKey) {
         switch key {
         case .digit(let digit): viewModel.amount.type(digit: digit)
         case .decimalPoint: viewModel.amount.typeDecimalPoint()
         case .backspace: viewModel.amount.backspace()
-        case .next:
-            if descriptionFocused {
-                save()
-            } else {
-                descriptionFocused = true
-            }
         }
     }
 
@@ -278,6 +110,7 @@ struct ExpenseSheet: View {
 
         Task {
             if let expense = await viewModel.save() {
+                savedCount += 1
                 onSaved(expense)
                 dismiss()
             }

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -263,6 +263,9 @@ struct GroupView: View {
                 .clipShape(Circle())
                 .shadow(radius: 8, y: 4)
         }
+        // The deepest press in the app: a 56pt disc under a thumb has to move a visible
+        // amount before the dip reads, and the shadow compressing with it sells the push.
+        .buttonStyle(.pressable(scale: 0.9))
         .padding(.trailing, 20)
         .padding(.vertical, 16)
         .disabled(currentUserId == nil || viewModel.group == nil)
@@ -386,7 +389,7 @@ struct ActionButton: View {
                 .background(color)
                 .cornerRadius(20)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.pressable(scale: 0.94))
     }
 }
 

--- a/Splitty/SplittyUITests/ExpenseSheetKeyboardTests.swift
+++ b/Splitty/SplittyUITests/ExpenseSheetKeyboardTests.swift
@@ -1,0 +1,175 @@
+//
+//  ExpenseSheetKeyboardTests.swift
+//  SplittyUITests
+//
+
+import XCTest
+
+/// The expense sheet is two steps, and the reason it is two steps is that the amount pad
+/// and the system keyboard must never contend for the bottom of the sheet. These pin that
+/// down: one input surface per screen, and a push to the split screen that does not disturb
+/// either.
+///
+/// Runs against whatever `SPLITTY_API_BASE_URL` points at, which by default is the
+/// deployed API — nothing local to stand up. Signs in through `/auth/dev-login` as a seeded
+/// user and reads: it never taps Save, so it writes nothing. Anything missing along the way
+/// is a skip rather than a failure, since these are about layout, not about the backend.
+final class ExpenseSheetKeyboardTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    /// The amount screen belongs to the pad alone.
+    @MainActor
+    func testTheAmountStepHasNoSystemKeyboard() throws {
+        let app = try launchOnAnExpenseSheet()
+
+        XCTAssertTrue(app.buttons["keypad.key.5"].exists, "The pad should own the amount step.")
+        XCTAssertFalse(
+            app.textFields["expense.description"].exists,
+            "Nothing on the amount step should be able to raise a system keyboard."
+        )
+    }
+
+    /// Forward is unavailable until there is an amount to carry forward.
+    @MainActor
+    func testNextIsBlockedUntilAnAmountIsTyped() throws {
+        let app = try launchOnAnExpenseSheet()
+
+        let next = app.buttons["expense.next"]
+        XCTAssertFalse(next.isEnabled, "Next should be blocked while the amount is zero.")
+
+        app.buttons["keypad.key.5"].tap()
+        XCTAssertTrue(next.isEnabled, "Next should open up as soon as there is an amount.")
+    }
+
+    /// The details screen belongs to the system keyboard alone.
+    @MainActor
+    func testTheDetailsStepReplacesThePadWithTheKeyboard() throws {
+        let app = try enterDetails(try launchOnAnExpenseSheet())
+
+        XCTAssertTrue(
+            waitForFocus(app.textFields["expense.description"]),
+            "The details step should arrive with the description already focused."
+        )
+        XCTAssertFalse(
+            app.buttons["keypad.key.5"].exists,
+            "The pad belongs to the previous screen and should not be on this one."
+        )
+    }
+
+    /// Save is the commit, and it stays blocked until the expense is actually saveable.
+    @MainActor
+    func testSaveIsBlockedUntilThereIsADescription() throws {
+        let app = try enterDetails(try launchOnAnExpenseSheet())
+        XCTAssertTrue(waitForFocus(app.textFields["expense.description"]))
+
+        let save = app.buttons["expense.save"]
+        XCTAssertFalse(save.isEnabled, "Save should be blocked without a description.")
+
+        app.typeText("dinner")
+        XCTAssertTrue(save.isEnabled, "Save should open up once the expense is complete.")
+    }
+
+    /// Pushing to the split screen and popping back lands on the details step with what was
+    /// typed still there. This is the round trip that used to come back misaligned.
+    @MainActor
+    func testPoppingBackFromSplitKeepsTheDetailsStepIntact() throws {
+        let app = try enterDetails(try launchOnAnExpenseSheet())
+        XCTAssertTrue(waitForFocus(app.textFields["expense.description"]))
+        app.typeText("dinner")
+
+        app.buttons["expense.split"].tap()
+        XCTAssertTrue(
+            app.otherElements["split.mode"].waitForExistence(timeout: 5)
+                || app.buttons["split.payer"].waitForExistence(timeout: 5),
+            "Expected the split screen to be pushed."
+        )
+
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+
+        let description = app.textFields["expense.description"]
+        XCTAssertTrue(
+            description.waitForExistence(timeout: 5),
+            "Popping back should land on the details step."
+        )
+        XCTAssertEqual(
+            description.value as? String, "dinner",
+            "The description should survive the push and pop."
+        )
+        XCTAssertFalse(
+            app.buttons["keypad.key.5"].exists,
+            "Popping back should not bring the amount pad onto the details step."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Whether the field actually holds keyboard focus.
+    ///
+    /// Not `app.keyboards`: the simulator runs with the hardware keyboard connected, so no
+    /// software keyboard is ever drawn and that collection is empty however focused the
+    /// field is. Focus is the thing under test either way — the drawn keyboard was only
+    /// ever a proxy for it.
+    private func waitForFocus(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if (element.value(forKey: "hasKeyboardFocus") as? Bool) == true { return true }
+            usleep(100_000)
+        }
+        return false
+    }
+
+    // MARK: - Getting there
+
+    private func enterDetails(_ app: XCUIApplication) throws -> XCUIApplication {
+        app.buttons["keypad.key.5"].tap()
+        app.buttons["keypad.key.0"].tap()
+        app.buttons["expense.next"].tap()
+        return app
+    }
+
+    /// Signs in as a seeded user, opens a group, and opens the add-expense sheet.
+    private func launchOnAnExpenseSheet() throws -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launch()
+
+        try signIn(app)
+
+        // Whichever group comes first: the sheet under test is the same one from any of
+        // them, and pinning a name here would tie the test to one backend's data.
+        let group = app.buttons["groups.card"].firstMatch
+        guard group.waitForExistence(timeout: 15) else {
+            throw XCTSkip("The signed-in user has no groups to open.")
+        }
+        group.tap()
+
+        let addExpense = app.buttons["group.addExpense"]
+        guard addExpense.waitForExistence(timeout: 15) else {
+            throw XCTSkip("The group never finished loading.")
+        }
+        addExpense.tap()
+
+        guard app.buttons["keypad.key.5"].waitForExistence(timeout: 10) else {
+            throw XCTSkip("The expense sheet did not open.")
+        }
+        return app
+    }
+
+    private func signIn(_ app: XCUIApplication) throws {
+        // Already signed in from a previous run: the token lives in the keychain.
+        if app.staticTexts["Groups"].waitForExistence(timeout: 5) { return }
+
+        let devSignIn = app.buttons["Dev sign in"]
+        guard devSignIn.waitForExistence(timeout: 10) else {
+            throw XCTSkip("Neither the login screen nor the groups list appeared.")
+        }
+        devSignIn.tap()
+        app.buttons["john@example.com"].tap()
+
+        guard app.staticTexts["Groups"].waitForExistence(timeout: 20) else {
+            throw XCTSkip("Dev sign-in did not complete; is the local API reachable?")
+        }
+    }
+}


### PR DESCRIPTION
Two independent commits; the second is the substantial one.

## `feat(ios): respond on the press, and add haptics`

Outside the expense sheet nothing had press feedback — cards, action pills and the add button were all `.plain`, so a tap did nothing visible until the release changed the screen. `PressableButtonStyle` carries it in one place, with the dip scaled inversely to target size (4% reads as nothing on a 56pt disc, as plenty on a full-width card). In fast, out slow.

The app also shipped without a single haptic. Added only where they are causal: keypad on press (soft, half intensity — it fires per digit), swipe row on a committed release, tab bar on selection.

Two real bugs in `SwipeToDeleteRow` fell out of that:

- **The snap-back animated nothing.** `.animation` was keyed on `offset`, which is always zero; the live drag rode a `@GestureState` that resets itself the instant the gesture ends, so the row went home in a single frame. It owns the value now and springs the release.
- **Commit ignored velocity.** A fast flick that stopped short of the 44pt threshold did nothing. Now judged on `predictedEndTranslation` too.

## `refactor(ios): split the expense sheet into amount, then details`

The sheet had two input surfaces competing for one strip: the amount pad and the system keyboard were both bottom-anchored, with a single floating arrow that changed meaning by focus — forward from the amount, save from the description — and so had to survive both. Keeping it in place meant opting out of keyboard avoidance and rebuilding the keyboard's height by hand from `keyboardWillChangeFrame`.

That reconstruction was the one *accumulated* value in an otherwise derived layout, and it was fed by every keyboard notification in the process — including ones belonging to the split screen pushed on top. Push and pop, and the sheet laid itself out against whatever the last message happened to say: content shifted, the date chip clipped off the sheet's top edge, the arrow drew over the keyboard.

**Two screens instead.** The amount owns one, pad permanently at its bottom, no text field anywhere on it. The details own the next, with the system keyboard and a Save that rides above it on SwiftUI's own avoidance. They cannot contend because they are never both present.

Deleted outright: `keyboardInset`, `bottomReserve`, `padBottomInset`, the measured pad heights, both `ignoresSafeArea(.keyboard)` calls, and the keypad's `showsDigits` / `isSaving` / `isNextEnabled` / action row. `KeypadKey.next` went with it — the pad is digits now. Each screen's commit is a full-width capsule that says what it does.

The details step is its own view because **focus is scoped to the view that declares it**: a `@FocusState` on the presenting screen does not reach a field inside a `navigationDestination`, and the binding silently does nothing across that boundary. `.onAppear` and `.defaultFocus` both failed before that was understood.

## Testing

`SplittyUITests/ExpenseSheetKeyboardTests` — 5/5 passing against the deployed API, no local stack and no `SPLITTY_API_BASE_URL` override. Read-only: no test taps Save. `SplittyTests` green, build clean.

Both commits build independently (verified the first in a detached worktree).

## Notes for review

- `ExpenseDetailsStep` focuses its field via `.task { sleep(400ms) }`. A focus request made during the push transition is dropped; this is the soft spot in the change and I would take a better idea.
- `GroupCard` gained a shared `groups.card` identifier so tests can ask for "a group" rather than a hardcoded name.
- The date moved from a chip on the amount screen to a row on the details screen.