### PR TITLE
feat(api): seed data with balances already computed

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,7 +30,7 @@ API ──> Service ──> Repository ──> Infrastructure (DbContext)
 | `Splitty.Domain` | Entities only, no behavior |
 | `Splitty.DTO` | `Request/`, `Response/`, `Internal/` |
 | `Splitty.Background` | `TransactionBackgroundService` — balance recomputation |
-| `Splitty.Seeder` | `DatabaseSeeder`, run via `dotnet run seed` |
+| `Splitty.Seeder` | `DatabaseSeeder` and `SeedCommand`, run via `dotnet run seed` |
 
 Everything is registered scoped in `Program.cs`, interface-first. Services and
 repositories use **primary constructors** for injection — match that style.
@@ -303,12 +303,31 @@ when its last member leaves (`POST /group/{groupId}/leave`).
 ```bash
 docker compose up -d                      # Postgres :5432, API :8080
 dotnet run --project Splitty-API/Splitty.API
-dotnet run --project Splitty-API/Splitty.API seed   # seed, then exit
+dotnet run --project Splitty-API/Splitty.API seed   # reset, seed, wait for balances, exit
 dotnet ef migrations add <Name> --project Splitty-API/Splitty.Infrastructure
 ```
 
 API listens on `0.0.0.0:8080` (Kestrel config in `appsettings.json`). In Development,
 OpenAPI is at `/openapi/v1.json` with Scalar UI at `/scalar`.
+
+### Seeding
+
+The seed command **starts the host** rather than seeding and returning: balances are
+written by a hosted service, so a process that enqueued and exited would leave every group
+`balancesPending` with no worker to clear it. It seeds, requests one recomputation per
+group through `IBalanceRecomputeQueue`, waits until no seeded group is pending, stops the
+host, and exits non-zero if that wait times out. The seeder never calls
+`CalculateGroupBalances` itself — invariant 4.
+
+The data set is **fixed, not random**: six users, a six-member group with amounts from
+$4.20 to $1,240, a two-member group, one group where `john@example.com` owes and one where
+he is owed, a pair settled to exactly zero, and a `Payment` row. `SeedData` holds it, and
+`DatabaseSeeder.Validate` rejects a row the API would have refused from a client.
+
+Re-running is safe because the command **clears the tables it owns first** — every
+`User`, `Group`, `Expense`, `ExpenseSplit`, `GroupMembership`, `Invite`, `OAuthAccount` and
+`Balance` row. It is a local development reset, not an upsert: anything created by hand in
+the dev database goes with it.
 
 ## Known issues
 

--- a/Splitty-API/Splitty.API.Tests/SeedTests.cs
+++ b/Splitty-API/Splitty.API.Tests/SeedTests.cs
@@ -1,0 +1,206 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Splitty.DTO.Internal;
+using Splitty.Seeder;
+
+namespace Splitty.API.Tests;
+
+/// <summary>
+/// Everything here reads what a signed-in client sees after `dotnet run seed`, never how
+/// the seeder built it. A test that counted rows through the context would pin today's
+/// data set and block the next edit to it.
+/// </summary>
+[Collection(nameof(ApiCollection))]
+public sealed class SeedTests(ApiFactory factory)
+{
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public async Task A_seeded_group_has_more_than_three_members()
+    {
+        await SeedAsync();
+
+        var groups = await GroupsOfAsync(DatabaseSeeder.PrimaryUserEmail);
+
+        Assert.Contains(groups, group => group.Members.Count > 3);
+    }
+
+    [Fact]
+    public async Task A_seeded_group_has_exactly_two_members()
+    {
+        await SeedAsync();
+
+        var groups = await GroupsOfAsync(DatabaseSeeder.PrimaryUserEmail);
+
+        Assert.Contains(groups, group => group.Members.Count == 2);
+    }
+
+    [Fact]
+    public async Task A_seeded_user_reads_nonzero_balances_in_some_group()
+    {
+        await SeedAsync();
+
+        var (client, groups) = await SignInAsync(DatabaseSeeder.PrimaryUserEmail);
+
+        var summaries = new List<BalanceSummary>();
+        foreach (var group in groups)
+        {
+            summaries.Add(await client.ReadSummaryAsync(group.Id));
+        }
+
+        Assert.Contains(summaries, summary => summary.Balances.Any(balance => balance.Amount != 0m));
+    }
+
+    [Fact]
+    public async Task No_seeded_group_is_left_pending()
+    {
+        await SeedAsync();
+
+        foreach (var email in DatabaseSeeder.UserEmails)
+        {
+            var (client, groups) = await SignInAsync(email);
+
+            foreach (var group in groups)
+            {
+                var summary = await client.ReadSummaryAsync(group.Id);
+                Assert.False(summary.BalancesPending, $"Group {group.Name} is still pending.");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task A_seeded_group_holds_a_pair_that_nets_to_zero()
+    {
+        await SeedAsync();
+
+        var (client, groups) = await SignInAsync(DatabaseSeeder.PrimaryUserEmail);
+
+        var balances = new List<BalanceEntry>();
+        foreach (var group in groups)
+        {
+            balances.AddRange((await client.ReadSummaryAsync(group.Id)).Balances);
+        }
+
+        Assert.Contains(balances, balance => balance.Amount == 0m);
+    }
+
+    [Fact]
+    public async Task The_first_seeded_user_is_a_debtor_in_one_group_and_a_creditor_in_another()
+    {
+        await SeedAsync();
+
+        var groups = await GroupsOfAsync(DatabaseSeeder.PrimaryUserEmail);
+
+        Assert.Contains(groups, group => group.NetBalance < 0m);
+        Assert.Contains(groups, group => group.NetBalance > 0m);
+    }
+
+    [Fact]
+    public async Task A_seeded_group_holds_a_settlement()
+    {
+        await SeedAsync();
+
+        var types = new List<string>();
+        foreach (var (_, expenses) in await SeededExpensesAsync())
+        {
+            types.AddRange(expenses.Select(expense => expense.GetProperty("type").GetString()!));
+        }
+
+        Assert.Contains("payment", types);
+    }
+
+    [Fact]
+    public async Task Every_seeded_expense_has_splits_that_sum_to_its_amount_with_no_zero_split()
+    {
+        await SeedAsync();
+
+        foreach (var (groupId, expenses) in await SeededExpensesAsync())
+        {
+            Assert.NotEmpty(expenses);
+
+            foreach (var expense in expenses)
+            {
+                var amount = expense.GetProperty("amount").GetDecimal();
+                var description = expense.GetProperty("description").GetString();
+                var splits = expense.GetProperty("splits")
+                    .EnumerateArray()
+                    .Select(split => split.GetProperty("amount").GetDecimal())
+                    .ToList();
+
+                Assert.DoesNotContain(splits, split => split == 0m);
+
+                if (expense.GetProperty("type").GetString() == "payment")
+                {
+                    // A settlement moves one amount between two people, so its splits
+                    // cancel rather than summing to the total.
+                    Assert.Equal(2, splits.Count);
+                    Assert.Equal(0m, splits.Sum());
+                    Assert.Equal(amount, Math.Abs(splits[0]));
+                    continue;
+                }
+
+                Assert.Equal(amount, splits.Sum());
+                Assert.NotEqual(JsonValueKind.Null, expense.GetProperty("splitMode").ValueKind);
+                Assert.NotNull(description);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Seeding_twice_does_not_duplicate_groups()
+    {
+        await SeedAsync();
+        await SeedAsync();
+
+        var names = (await GroupsOfAsync(DatabaseSeeder.PrimaryUserEmail))
+            .Select(group => group.Name)
+            .ToList();
+
+        Assert.Equal(names.Distinct().Count(), names.Count);
+    }
+
+    private async Task SeedAsync()
+    {
+        await factory.DrainProcessedAsync();
+
+        var outcome = await SeedCommand.SeedAndDrainAsync(factory.Services, TimeSpan.FromSeconds(30));
+
+        Assert.True(outcome.Drained, "The seed command gave up before the worker drained.");
+        Assert.NotEmpty(outcome.GroupIds);
+    }
+
+    private async Task<IReadOnlyList<(int GroupId, IReadOnlyList<JsonElement> Expenses)>> SeededExpensesAsync()
+    {
+        var seen = new Dictionary<int, IReadOnlyList<JsonElement>>();
+
+        foreach (var email in DatabaseSeeder.UserEmails)
+        {
+            var (client, groups) = await SignInAsync(email);
+
+            foreach (var group in groups.Where(group => !seen.ContainsKey(group.Id)))
+            {
+                var body = await client.ReadJsonAsync(await client.GetExpensesAsync(group.Id));
+                seen[group.Id] = body.EnumerateArray().ToList();
+            }
+        }
+
+        return seen.Select(entry => (entry.Key, entry.Value)).ToList();
+    }
+
+    private async Task<IReadOnlyList<GroupDTO>> GroupsOfAsync(string email) =>
+        (await SignInAsync(email)).Groups;
+
+    private async Task<(ApiClient Client, IReadOnlyList<GroupDTO> Groups)> SignInAsync(string email)
+    {
+        var response = await ApiClient.Create(factory).Http
+            .PostAsJsonAsync("/auth/dev-login", new { email });
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+        var client = ApiClient.Create(factory, body.GetProperty("token").GetString());
+
+        var groups = await client.Http.GetFromJsonAsync<List<GroupDTO>>("/group", Json);
+
+        return (client, groups!);
+    }
+}

--- a/Splitty-API/Splitty.API/Program.cs
+++ b/Splitty-API/Splitty.API/Program.cs
@@ -205,14 +205,15 @@ app.UseRateLimiter();
 
 app.MapControllers();
 
+// The seed command runs the host: the recomputation it requests is performed by a hosted
+// service, so seeding and returning would queue work no worker is there to do.
 if (args.Contains("seed"))
 {
-    using var scope = app.Services.CreateScope();
-    var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-    DatabaseSeeder.Seed(dbContext);
-    return;
+    return await SeedCommand.RunAsync(app);
 }
 
 app.Run();
+
+return 0;
 
 public partial class Program;

--- a/Splitty-API/Splitty.Seeder/DatabaseSeeder.cs
+++ b/Splitty-API/Splitty.Seeder/DatabaseSeeder.cs
@@ -1,134 +1,175 @@
+using Microsoft.EntityFrameworkCore;
+using Splitty.Background;
 using Splitty.Domain.Entities;
 using Splitty.Infrastructure;
 
 namespace Splitty.Seeder;
 
-public class DatabaseSeeder
+/// <summary>
+/// Writes the development data set and asks for its balances.
+///
+/// It requests a recomputation per group through <see cref="IBalanceRecomputeQueue"/> and
+/// never replays balances itself: invariant 4 says the replay has exactly one caller, the
+/// background worker, and a test pins that caller list.
+/// </summary>
+public sealed class DatabaseSeeder(ApplicationDbContext context, IBalanceRecomputeQueue queue)
 {
-    private static readonly Random _random = new Random();
-    
-    public static void Seed(ApplicationDbContext context)
+    /// <summary>The seeded addresses, in seed order. `POST /auth/dev-login` takes any of them.</summary>
+    public static IReadOnlyList<string> UserEmails { get; } =
+        SeedData.Users.Select(user => user.Email).ToList();
+
+    /// <summary>
+    /// The user a developer signs in as by default. The data set is arranged around them:
+    /// they owe in one group and are owed in another.
+    /// </summary>
+    public static string PrimaryUserEmail => SeedData.John;
+
+    /// <summary>
+    /// Resets the tables the seeder owns, writes the data set, and enqueues one
+    /// recomputation per group. Returns the seeded group ids, in seed order.
+    /// </summary>
+    public async Task<IReadOnlyList<int>> SeedAsync(CancellationToken cancellationToken = default)
     {
-        var users = new List<User>
-        {
-            new() { Name = "John Doe", Email = "john@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
-            new() { Name = "Jane Smith", Email = "jane@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
-            new() { Name = "Bob Wilson", Email = "bob@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
-            new() { Name = "Alice Brown", Email = "alice@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
-            new() { Name = "Charlie Davis", Email = "charlie@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
-            new() { Name = "Eva Johnson", Email = "eva@example.com", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
-        };
-        context.User.AddRange(users);
-        context.SaveChanges();
+        await ResetAsync(cancellationToken);
 
-        var groups = new List<Group>
-        {
-            new() { Name = "Vacation Trip", Description = "Summer vacation expenses", CreatedBy = users[0].Id, CreatedAt = DateTime.UtcNow, CreatedByUser = users[0] },
-            new() { Name = "Shared Apartment", Description = "Monthly apartment expenses", CreatedBy = users[1].Id, CreatedAt = DateTime.UtcNow, CreatedByUser = users[1] },
-            new() { Name = "Game Night", Description = "Weekly game night expenses", CreatedBy = users[2].Id, CreatedAt = DateTime.UtcNow, CreatedByUser = users[2] }
-        };
-        context.Group.AddRange(groups);
-        context.SaveChanges();
+        var users = SeedData.Users.ToDictionary(
+            seeded => seeded.Email,
+            seeded => new User { Name = seeded.Name, Email = seeded.Email });
 
-        var memberships = new List<GroupMembership>();
-        foreach (var group in groups)
+        context.User.AddRange(users.Values);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var groupIds = new List<int>();
+
+        foreach (var seededGroup in SeedData.Groups)
         {
-            // Get 3 random users for each group
-            var groupUsers = users.OrderBy(x => _random.Next()).Take(3).ToList();
-            foreach (var user in groupUsers)
+            var group = new Group
             {
-                memberships.Add(new GroupMembership
+                Name = seededGroup.Name,
+                Description = seededGroup.Description,
+                CreatedBy = users[seededGroup.CreatedBy].Id,
+                Members = seededGroup.Members
+                    .Select(email => new GroupMembership { UserId = users[email].Id })
+                    .ToList()
+            };
+
+            context.Group.Add(group);
+            await context.SaveChangesAsync(cancellationToken);
+
+            foreach (var entry in seededGroup.Entries)
+            {
+                Validate(entry);
+
+                context.Expense.Add(new Expense
                 {
                     GroupId = group.Id,
-                    UserId = user.Id,
-                    JoinedAt = DateTime.UtcNow,
-                    User = user,
-                    Group = group
+                    Description = entry.Description,
+                    Amount = entry.Amount,
+                    PaidBy = users[entry.PaidBy].Id,
+                    Type = entry.Type,
+                    SplitMode = entry.Mode,
+                    Date = DateTime.UtcNow.Date.AddDays(-entry.DaysAgo),
+                    Splits = entry.Splits
+                        .Select(split => new ExpenseSplit
+                        {
+                            UserId = users[split.Email].Id,
+                            Amount = split.Amount,
+                            Percentage = split.Percentage
+                        })
+                        .ToList()
                 });
             }
-        }
-        context.GroupMembership.AddRange(memberships);
-        context.SaveChanges();
 
-        foreach (var group in groups)
+            await context.SaveChangesAsync(cancellationToken);
+            groupIds.Add(group.Id);
+        }
+
+        foreach (var groupId in groupIds)
         {
-            var groupMemberships = memberships.Where(m => m.GroupId == group.Id).ToList();
-            
-            // Create 10 expenses per group
-            for (int i = 0; i < 10; i++)
-            {
-                // Random amount between 10 and 200
-                var amount = Math.Round((decimal)(_random.NextDouble() * 190 + 10), 2);
-                
-                // Random payer from group members
-                var payer = groupMemberships[_random.Next(groupMemberships.Count)].User;
-
-                // One percentage expense per group, so a client opening the seed data has
-                // a real percentage split to read rather than only equal ones.
-                var mode = i == 0 ? SplitMode.Percentage : SplitMode.Equal;
-
-                var expense = new Expense
-                {
-                    GroupId = group.Id,
-                    PaidBy = payer.Id,
-                    Amount = amount,
-                    Description = GetRandomExpenseDescription(),
-                    Type = ExpenseType.Expense,
-                    SplitMode = mode,
-                    CreatedAt = DateTime.UtcNow,
-                    UpdatedAt = DateTime.UtcNow,
-                    Group = group,
-                    PaidByUser = payer
-                };
-                context.Expense.Add(expense);
-                context.SaveChanges();
-
-                var splitAmount = Math.Round(amount / groupMemberships.Count, 2);
-
-                // Amounts stay evenly divided either way: the mode describes how the split
-                // was chosen, it is never what the amounts are computed from. The last
-                // member absorbs the percentage remainder for the same reason.
-                var evenPercentage = Math.Round(100m / groupMemberships.Count, 2);
-                var splits = groupMemberships.Select((m, index) => new ExpenseSplit
-                {
-                    ExpenseId = expense.Id,
-                    UserId = m.UserId,
-                    Amount = splitAmount,
-                    Percentage = mode == SplitMode.Percentage
-                        ? index == groupMemberships.Count - 1
-                            ? 100m - evenPercentage * (groupMemberships.Count - 1)
-                            : evenPercentage
-                        : null,
-                    Expense = expense,
-                    User = m.User
-                }).ToList();
-                
-                context.ExpenseSplit.AddRange(splits);
-                context.SaveChanges();
-            }
+            await queue.EnqueueAsync(groupId, cancellationToken);
         }
+
+        return groupIds;
     }
 
-    private static string GetRandomExpenseDescription()
+    /// <summary>
+    /// Clearing first is what makes a second run safe. Appending a second "Game Night"
+    /// would be worse than refusing, and refusing would mean dropping the database by hand
+    /// to get back to a known state. Everything here is development-only data.
+    /// </summary>
+    private async Task ResetAsync(CancellationToken cancellationToken)
     {
-        var descriptions = new[]
+        // Child rows first: nothing relies on a cascade being configured.
+        await context.Balance.ExecuteDeleteAsync(cancellationToken);
+        await context.ExpenseSplit.ExecuteDeleteAsync(cancellationToken);
+        await context.Expense.ExecuteDeleteAsync(cancellationToken);
+        await context.Invite.ExecuteDeleteAsync(cancellationToken);
+        await context.GroupMembership.ExecuteDeleteAsync(cancellationToken);
+        await context.Group.ExecuteDeleteAsync(cancellationToken);
+        await context.OAuthAccount.ExecuteDeleteAsync(cancellationToken);
+        await context.User.ExecuteDeleteAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// The rules the API enforces on a client, checked against the data set so a seeded row
+    /// is never one the API would have refused — a row the app cannot re-save is a trap for
+    /// whoever edits it next. Deliberately duplicated rather than shared:
+    /// <c>ExpenseSplitInvariants</c> is internal to Splitty.Service, and this checks static
+    /// data at write time rather than a request. A stray percentage is refused here though
+    /// the API would null it, because seeded data should say what it means.
+    /// </summary>
+    private static void Validate(SeedEntry entry)
+    {
+        if (entry.Type is ExpenseType.Payment)
         {
-            "Groceries",
-            "Restaurant bill",
-            "Movie tickets",
-            "Utilities",
-            "Pizza night",
-            "Transportation",
-            "Coffee run",
-            "Office supplies",
-            "Snacks",
-            "Party supplies",
-            "Cleaning supplies",
-            "Take out food",
-            "Entertainment",
-            "Group activity"
-        };
-        
-        return descriptions[_random.Next(descriptions.Length)];
+            if (entry.Mode is not null
+                || entry.Splits.Count != 2
+                || entry.Splits.Sum(split => split.Amount) != 0m
+                || Math.Abs(entry.Splits[0].Amount) != entry.Amount)
+            {
+                throw new InvalidOperationException(
+                    $"Seeded settlement '{entry.Description}' is not a valid payment.");
+            }
+
+            return;
+        }
+
+        if (entry.Mode is null)
+        {
+            throw new InvalidOperationException($"Seeded expense '{entry.Description}' has no split mode.");
+        }
+
+        if (entry.Amount <= 0m || entry.Splits.Count == 0)
+        {
+            throw new InvalidOperationException($"Seeded expense '{entry.Description}' has nothing to split.");
+        }
+
+        if (entry.Splits.Any(split => split.Amount <= 0m))
+        {
+            throw new InvalidOperationException(
+                $"Seeded expense '{entry.Description}' has a split at or below zero. Omit the member instead.");
+        }
+
+        if (entry.Splits.Sum(split => split.Amount) != entry.Amount)
+        {
+            throw new InvalidOperationException(
+                $"Seeded expense '{entry.Description}' has splits that do not sum to its amount.");
+        }
+
+        var percentages = entry.Splits.Where(split => split.Percentage is not null).ToList();
+
+        if (entry.Mode is SplitMode.Percentage)
+        {
+            if (percentages.Count != entry.Splits.Count || percentages.Sum(split => split.Percentage!.Value) != 100m)
+            {
+                throw new InvalidOperationException(
+                    $"Seeded expense '{entry.Description}' must carry percentages on every split, summing to 100.");
+            }
+        }
+        else if (percentages.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Seeded expense '{entry.Description}' carries a percentage outside a percentage split.");
+        }
     }
 }

--- a/Splitty-API/Splitty.Seeder/SeedCommand.cs
+++ b/Splitty-API/Splitty.Seeder/SeedCommand.cs
@@ -1,0 +1,124 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Splitty.Background;
+using Splitty.Infrastructure;
+
+namespace Splitty.Seeder;
+
+/// <summary>
+/// What a seeded group looked like when the command gave up or finished.
+/// </summary>
+/// <param name="GroupIds">The groups written, in seed order.</param>
+/// <param name="Drained">
+/// True once every seeded group's balances have been recomputed. False means the wait
+/// timed out with groups still pending, which the command reports as a failure: a seed
+/// that half-finished leaves the client greying numbers that will never change.
+/// </param>
+public sealed record SeedOutcome(IReadOnlyList<int> GroupIds, bool Drained);
+
+/// <summary>
+/// `dotnet run --project Splitty-API/Splitty.API seed`.
+///
+/// The command starts the host rather than seeding and returning, because the recomputation
+/// it requests is performed by a hosted service. Enqueueing without a running worker would
+/// mark every group pending and then drop the messages on exit, which is worse than seeding
+/// nothing at all.
+/// </summary>
+public static class SeedCommand
+{
+    private static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(60);
+
+    public static async Task<int> RunAsync(IHost host, CancellationToken cancellationToken = default)
+    {
+        var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(SeedCommand));
+
+        await host.StartAsync(cancellationToken);
+
+        try
+        {
+            var outcome = await SeedAndDrainAsync(host.Services, DefaultDrainTimeout, cancellationToken);
+
+            if (!outcome.Drained)
+            {
+                logger.LogError(
+                    "Seeded {Count} groups but their balances were not recomputed within {Seconds}s.",
+                    outcome.GroupIds.Count,
+                    DefaultDrainTimeout.TotalSeconds);
+
+                return 1;
+            }
+
+            logger.LogInformation(
+                "Seeded {Count} groups with balances computed. Sign in with {Email}.",
+                outcome.GroupIds.Count,
+                DatabaseSeeder.PrimaryUserEmail);
+
+            return 0;
+        }
+        finally
+        {
+            await host.StopAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Seeds, then waits until no seeded group is pending. The wait is driven by the
+    /// worker's own completion signal rather than by polling on a timer, and is bounded:
+    /// the caller gets an answer either way instead of hanging.
+    /// </summary>
+    public static async Task<SeedOutcome> SeedAndDrainAsync(
+        IServiceProvider services,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<int> groupIds;
+
+        using (var scope = services.CreateScope())
+        {
+            var seeder = ActivatorUtilities.CreateInstance<DatabaseSeeder>(scope.ServiceProvider);
+            groupIds = await seeder.SeedAsync(cancellationToken);
+        }
+
+        return new SeedOutcome(groupIds, await WaitForDrainAsync(services, groupIds, timeout, cancellationToken));
+    }
+
+    private static async Task<bool> WaitForDrainAsync(
+        IServiceProvider services,
+        IReadOnlyList<int> groupIds,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var signal = services.GetRequiredService<TransactionProcessedSignal>();
+        var deadline = DateTime.UtcNow + timeout;
+
+        // The signal says "a message was processed", not "yours was", so it paces the loop
+        // and the pending flags decide when to stop. Counting signals instead would let a
+        // message enqueued by something else end the wait early.
+        while (await PendingCountAsync(services, groupIds, cancellationToken) > 0)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+
+            if (remaining <= TimeSpan.Zero || !await signal.WaitAsync(remaining, cancellationToken))
+            {
+                return await PendingCountAsync(services, groupIds, cancellationToken) == 0;
+            }
+        }
+
+        return true;
+    }
+
+    private static async Task<int> PendingCountAsync(
+        IServiceProvider services,
+        IReadOnlyList<int> groupIds,
+        CancellationToken cancellationToken)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        return await context.Group
+            .Where(group => groupIds.Contains(group.Id) && group.BalancesPending)
+            .CountAsync(cancellationToken);
+    }
+}

--- a/Splitty-API/Splitty.Seeder/SeedData.cs
+++ b/Splitty-API/Splitty.Seeder/SeedData.cs
@@ -1,0 +1,241 @@
+using Splitty.Domain.Entities;
+
+namespace Splitty.Seeder;
+
+/// <summary>
+/// The development data set, written out rather than generated. It used to be random
+/// members and random amounts, which is what hid the fact that nothing ever recomputed
+/// balances: every run looked different, so "all zeros" read as one more random outcome.
+///
+/// The shapes here are the cases a screen has to survive — a six-member group, a
+/// two-member group, amounts from a few euros to four figures, one debtor group, one
+/// creditor group, a pair settled to exactly zero, and a percentage split.
+/// </summary>
+internal static class SeedData
+{
+    public const string John = "john@example.com";
+    public const string Jane = "jane@example.com";
+    public const string Bob = "bob@example.com";
+    public const string Alice = "alice@example.com";
+    public const string Charlie = "charlie@example.com";
+    public const string Eva = "eva@example.com";
+
+    /// <summary>
+    /// Kept as they were: `POST /auth/dev-login` and the docs name these addresses.
+    /// </summary>
+    public static readonly IReadOnlyList<SeedUser> Users =
+    [
+        new("John Doe", John),
+        new("Jane Smith", Jane),
+        new("Bob Wilson", Bob),
+        new("Alice Brown", Alice),
+        new("Charlie Davis", Charlie),
+        new("Eva Johnson", Eva)
+    ];
+
+    public static readonly IReadOnlyList<SeedGroup> Groups =
+    [
+        // Six members and a spread of two and a half orders of magnitude, so a
+        // proportional layout meets real extremes. John pays the hotel, so he is the
+        // creditor here.
+        new(
+            Name: "Weekend in Lisbon",
+            Description: "Flights, hotel and everything after",
+            CreatedBy: John,
+            Members: [John, Jane, Bob, Alice, Charlie, Eva],
+            Entries:
+            [
+                new SeedEntry(
+                    Description: "Hotel",
+                    Amount: 1240.00m,
+                    PaidBy: John,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 12,
+                    Splits:
+                    [
+                        new SeedSplit(John, 206.67m),
+                        new SeedSplit(Jane, 206.67m),
+                        new SeedSplit(Bob, 206.67m),
+                        new SeedSplit(Alice, 206.67m),
+                        new SeedSplit(Charlie, 206.67m),
+                        // Absorbs the remainder cent, the way a client does.
+                        new SeedSplit(Eva, 206.65m)
+                    ]),
+                new SeedEntry(
+                    Description: "Flights",
+                    Amount: 892.50m,
+                    PaidBy: Jane,
+                    Mode: SplitMode.Custom,
+                    DaysAgo: 11,
+                    // Three of the six flew together; the rest are simply not on the row.
+                    Splits:
+                    [
+                        new SeedSplit(John, 312.50m),
+                        new SeedSplit(Jane, 312.50m),
+                        new SeedSplit(Bob, 267.50m)
+                    ]),
+                new SeedEntry(
+                    Description: "Dinner at Belcanto",
+                    Amount: 465.00m,
+                    PaidBy: Eva,
+                    Mode: SplitMode.Percentage,
+                    DaysAgo: 9,
+                    Splits:
+                    [
+                        new SeedSplit(Eva, 186.00m, 40m),
+                        new SeedSplit(John, 139.50m, 30m),
+                        new SeedSplit(Alice, 93.00m, 20m),
+                        new SeedSplit(Charlie, 46.50m, 10m)
+                    ]),
+                new SeedEntry(
+                    Description: "Taxi from the airport",
+                    Amount: 38.40m,
+                    PaidBy: Bob,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 12,
+                    Splits:
+                    [
+                        new SeedSplit(Bob, 9.60m),
+                        new SeedSplit(Alice, 9.60m),
+                        new SeedSplit(Charlie, 9.60m),
+                        new SeedSplit(Eva, 9.60m)
+                    ]),
+                new SeedEntry(
+                    Description: "Pastéis de nata",
+                    Amount: 9.75m,
+                    PaidBy: Charlie,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 8,
+                    Splits:
+                    [
+                        new SeedSplit(Charlie, 3.25m),
+                        new SeedSplit(Jane, 3.25m),
+                        new SeedSplit(Eva, 3.25m)
+                    ]),
+                new SeedEntry(
+                    Description: "Postcards",
+                    Amount: 4.20m,
+                    PaidBy: Alice,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 7,
+                    Splits:
+                    [
+                        new SeedSplit(Alice, 2.10m),
+                        new SeedSplit(John, 2.10m)
+                    ])
+            ]),
+
+        // The smallest case, and the one where John owes: Jane carries the rent.
+        new(
+            Name: "Apartment 4B",
+            Description: "Rent, bills and the occasional repair",
+            CreatedBy: Jane,
+            Members: [John, Jane],
+            Entries:
+            [
+                new SeedEntry(
+                    Description: "Rent",
+                    Amount: 1850.00m,
+                    PaidBy: Jane,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 20,
+                    Splits: [new SeedSplit(John, 925.00m), new SeedSplit(Jane, 925.00m)]),
+                new SeedEntry(
+                    Description: "Electricity",
+                    Amount: 96.40m,
+                    PaidBy: Jane,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 18,
+                    Splits: [new SeedSplit(John, 48.20m), new SeedSplit(Jane, 48.20m)]),
+                new SeedEntry(
+                    Description: "Internet",
+                    Amount: 79.90m,
+                    PaidBy: John,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 17,
+                    Splits: [new SeedSplit(John, 39.95m), new SeedSplit(Jane, 39.95m)])
+            ]),
+
+        // John repays Bob in full, so that pair sits at exactly zero — something for a
+        // "hide settled pairs" rule to hide — and the timeline carries a payment row.
+        new(
+            Name: "Game Night",
+            Description: "Weekly board games and takeaway",
+            CreatedBy: Bob,
+            Members: [John, Jane, Bob, Alice],
+            Entries:
+            [
+                new SeedEntry(
+                    Description: "Pizza",
+                    Amount: 68.00m,
+                    PaidBy: Bob,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 5,
+                    Splits:
+                    [
+                        new SeedSplit(John, 17.00m),
+                        new SeedSplit(Jane, 17.00m),
+                        new SeedSplit(Bob, 17.00m),
+                        new SeedSplit(Alice, 17.00m)
+                    ]),
+                new SeedEntry(
+                    Description: "Board game rental",
+                    Amount: 24.00m,
+                    PaidBy: Alice,
+                    Mode: SplitMode.Equal,
+                    DaysAgo: 4,
+                    Splits:
+                    [
+                        new SeedSplit(John, 8.00m),
+                        new SeedSplit(Jane, 8.00m),
+                        new SeedSplit(Alice, 8.00m)
+                    ]),
+                SeedEntry.Payment(
+                    description: "Payment to Bob Wilson",
+                    amount: 17.00m,
+                    paidBy: John,
+                    peer: Bob,
+                    daysAgo: 3)
+            ])
+    ];
+}
+
+internal sealed record SeedUser(string Name, string Email);
+
+internal sealed record SeedGroup(
+    string Name,
+    string Description,
+    string CreatedBy,
+    IReadOnlyList<string> Members,
+    IReadOnlyList<SeedEntry> Entries);
+
+internal sealed record SeedSplit(string Email, decimal Amount, decimal? Percentage = null);
+
+internal sealed record SeedEntry(
+    string Description,
+    decimal Amount,
+    string PaidBy,
+    SplitMode? Mode,
+    int DaysAgo,
+    IReadOnlyList<SeedSplit> Splits,
+    ExpenseType Type = ExpenseType.Expense)
+{
+    /// <summary>
+    /// A settlement, built the way <c>BalanceService.SettleUp</c> builds one: no split
+    /// mode, and two splits that cancel.
+    /// </summary>
+    public static SeedEntry Payment(
+        string description,
+        decimal amount,
+        string paidBy,
+        string peer,
+        int daysAgo) =>
+        new(
+            description,
+            amount,
+            paidBy,
+            Mode: null,
+            daysAgo,
+            Splits: [new SeedSplit(paidBy, amount), new SeedSplit(peer, -amount)],
+            Type: ExpenseType.Payment);
+}

--- a/Splitty-API/Splitty.Seeder/Splitty.Seeder.csproj
+++ b/Splitty-API/Splitty.Seeder/Splitty.Seeder.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Splitty.Background\Splitty.Background.csproj" />
       <ProjectReference Include="..\Splitty.Infrastructure\Splitty.Infrastructure.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Closes #42

## Problem

`dotnet run seed` produced a database that lied: it wrote users, groups, expenses and splits and never asked for a balance recomputation, so every seeded group reported everyone settled. Random members and amounts hid it — "all zeros" read as one more random outcome rather than as the constant it was.

## What changed

| File | What |
|---|---|
| `Splitty.Seeder/SeedData.cs` (new) | The fixed data set — six users, three groups, explicit splits |
| `Splitty.Seeder/DatabaseSeeder.cs` | Instance class taking `IBalanceRecomputeQueue`; resets, writes, enqueues, validates each row against the API's split rules |
| `Splitty.Seeder/SeedCommand.cs` (new) | Starts the host, seeds, waits until no seeded group is pending, stops, returns an exit code |
| `Splitty.API/Program.cs` | Seed branch is now `return await SeedCommand.RunAsync(app)` |
| `Splitty.API.Tests/SeedTests.cs` (new) | 9 tests, all reading back through the API as a dev-logged-in user |
| `CONTEXT.md` | New "Seeding" section |

The seed command **starts the host** rather than seeding and returning: balances are written by a hosted service, so enqueueing and exiting would mark every group pending with no worker to clear it. The seeder requests through the queue and never calls `CalculateGroupBalances` — invariant 4 holds, and the test pinning the caller list passes unchanged.

## The data set

- **Weekend in Lisbon** — 6 members, amounts from `4.20` to `1240.00`, John is owed `+579.23`. Includes a percentage split and a custom split where three of six members are on the row.
- **Apartment 4B** — 2 members, John owes `-933.25`.
- **Game Night** — 4 members; John repays Bob in full through a `Payment` row, so that pair sits at exactly `0.00` for a "hide settled pairs" rule to hide.

Re-running is safe: the command clears the tables it owns first. It is a local development reset, not an upsert.

## Verification

- Full suite green (87/87).
- Real end-to-end run against a throwaway Postgres: exit 0, `Seeded 3 groups with balances computed`, member counts 6/4/2, John's nets `+579.23 / -933.25 / -8.00`, two zero balance rows. A second run produced no duplicates.