### PR TITLE
feat(ios): add group balances sheet

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,8 @@ resolving a fresh scope per message.
 
 So **balances are eventually consistent** — right after creating an expense, a read may
 still return pre-expense numbers. The client must not assume a write is immediately
-reflected.
+reflected. A group's net balance is the sum of the signed-in member's pairwise `Balance`
+rows; the overall figure on the groups list is the sum of those group nets.
 
 `Group.BalancesPending`, surfaced as `balancesPending` on the summary response, says a
 recomputation is outstanding. It is a **display hint only**: it exists so a client can show

--- a/Splitty/Splitty/Components/GroupCard.swift
+++ b/Splitty/Splitty/Components/GroupCard.swift
@@ -12,7 +12,7 @@ struct GroupCard: View {
     let onTap: () -> Void
     
     var positiveBalance: Bool {
-        return (group.netBalance) > 0;
+        return group.netBalanceCents > 0;
     }
     
     var body: some View {
@@ -28,10 +28,10 @@ struct GroupCard: View {
                             .fontWeight(.semibold)
                             .padding(.bottom, 2)
                         
-                        Text((group.netBalance) > 0 ? "You are owed" : "You owe")
+                        Text(group.netBalanceCents > 0 ? "You are owed" : "You owe")
                             .font(.system(size: 12))
                         
-                        Text("$\(String(format: "%.2f", abs(group.netBalance)))")
+                        Text(Money.formatted(cents: abs(group.netBalanceCents)))
                             .font(.system(size: 18))
                             .fontWeight(.bold)
                             .foregroundColor(positiveBalance ? .green : .red)
@@ -62,7 +62,7 @@ struct GroupCard: View {
         id: 1,
         name: "Test Group",
         description: "Test Description",
-        netBalance: 430.28,
+        netBalanceCents: 43_028,
         createdAt: "2025-02-02T13:53:41.950093Z",
         members: [
             GroupMember(
@@ -79,7 +79,7 @@ struct GroupCard: View {
         id: 1,
         name: "Test Group",
         description: "Test Description",
-        netBalance: -340.12,
+        netBalanceCents: -34_012,
         createdAt: "2025-02-02T13:53:41.950093Z",
         members: [
             GroupMember(

--- a/Splitty/Splitty/Models/Groups.swift
+++ b/Splitty/Splitty/Models/Groups.swift
@@ -12,9 +12,14 @@ struct Group: Codable, Identifiable {
     let id: Int
     let name: String
     let description: String?
-    let netBalance: Double
+    @DecodedCents var netBalanceCents: Int
     let createdAt: String
     let members: [GroupMember]
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, description, createdAt, members
+        case netBalanceCents = "netBalance"
+    }
 }
 
 // MARK: - Group Member Model

--- a/Splitty/Splitty/Models/Money.swift
+++ b/Splitty/Splitty/Models/Money.swift
@@ -10,6 +10,27 @@ import Foundation
 /// The API validates that splits sum **exactly** to the total against a `decimal` column.
 /// Deriving splits in `Double` makes that a coin flip; deriving them in cents makes it a
 /// property of the arithmetic. Conversion happens once, at the request boundary.
+/// Decodes a decimal JSON amount into the integer-cent representation used everywhere
+/// after the transport boundary.
+@propertyWrapper
+struct DecodedCents: Codable, Equatable {
+    var wrappedValue: Int
+
+    init(wrappedValue: Int) {
+        self.wrappedValue = wrappedValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = Money.cents(from: try container.decode(Decimal.self))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(Decimal(wrappedValue) / 100)
+    }
+}
+
 enum Money {
     static func cents(from value: Decimal) -> Int {
         var rounded = Decimal()

--- a/Splitty/Splitty/Models/User.swift
+++ b/Splitty/Splitty/Models/User.swift
@@ -5,10 +5,18 @@
 //  Created by Snowye on 06/02/25.
 //
 
+import Foundation
+
 struct User: Codable, Identifiable {
     var id: Int;
     var name: String;
     var email: String;
+    var avatarURL: URL? = nil;
     var createdAt: String;
     var updatedAt: String;
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, email, createdAt, updatedAt
+        case avatarURL = "avatarUrl"
+    }
 }

--- a/Splitty/Splitty/Models/User.swift
+++ b/Splitty/Splitty/Models/User.swift
@@ -19,4 +19,41 @@ struct User: Codable, Identifiable {
         case id, name, email, createdAt, updatedAt
         case avatarURL = "avatarUrl"
     }
+
+    init(
+        id: Int,
+        name: String,
+        email: String,
+        avatarURL: URL? = nil,
+        createdAt: String,
+        updatedAt: String
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.avatarURL = avatarURL
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(Int.self, forKey: .id)
+        name = try values.decode(String.self, forKey: .name)
+        email = try values.decode(String.self, forKey: .email)
+        let avatarString = try values.decodeIfPresent(String.self, forKey: .avatarURL)
+        avatarURL = avatarString.flatMap { $0.isEmpty ? nil : URL(string: $0) }
+        createdAt = try values.decode(String.self, forKey: .createdAt)
+        updatedAt = try values.decode(String.self, forKey: .updatedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(id, forKey: .id)
+        try values.encode(name, forKey: .name)
+        try values.encode(email, forKey: .email)
+        try values.encodeIfPresent(avatarURL?.absoluteString, forKey: .avatarURL)
+        try values.encode(createdAt, forKey: .createdAt)
+        try values.encode(updatedAt, forKey: .updatedAt)
+    }
 }

--- a/Splitty/Splitty/Networking/APIClient.swift
+++ b/Splitty/Splitty/Networking/APIClient.swift
@@ -258,14 +258,7 @@ struct GroupMutationResponse: Codable, Identifiable {
     let description: String?
 }
 
-struct GroupDetail: Codable, Identifiable {
-    let id: Int
-    let name: String
-    let description: String?
-    let netBalance: Double
-    let createdAt: String
-    let members: [GroupMember]
-}
+typealias GroupDetail = Group
 
 struct GroupMembership: Codable, Identifiable {
     let id: Int
@@ -275,17 +268,23 @@ struct GroupMembership: Codable, Identifiable {
     let user: User
 }
 
-/// `GET /group/{id}/expenses/summary`. Only the flag is decoded: the header reads its
-/// number from the group itself, and the pairwise rows have no screen yet.
 struct GroupBalanceSummary: Codable {
+    let balances: [Balance]
     /// A display hint only: true while a recomputation is queued or in flight.
     let balancesPending: Bool
 }
 
 struct Balance: Codable {
     let userId: Int
-    let amount: Double
+    let peerId: Int
+    @DecodedCents var amountCents: Int
     let user: User
+    let peer: User
+
+    private enum CodingKeys: String, CodingKey {
+        case userId, peerId, user, peer
+        case amountCents = "amount"
+    }
 }
 
 // MARK: - Empty Response for DELETE operations

--- a/Splitty/Splitty/Services/GroupService.swift
+++ b/Splitty/Splitty/Services/GroupService.swift
@@ -34,6 +34,13 @@ class GroupService {
         try await APIClient.shared.request(endpoint: "/group/\(groupId)/expenses/summary")
     }
 
+    func requestBalanceRecomputation(groupId: Int) async throws {
+        let _: EmptyResponse = try await APIClient.shared.request(
+            endpoint: "/group/\(groupId)/expenses/summary",
+            method: .POST
+        )
+    }
+
     /// Redeems an invite code. The response identifies the group — the caller never
     /// supplies a group id. Redeeming a code for a group you already belong to
     /// succeeds and returns that group.

--- a/Splitty/Splitty/ViewModels/BalancesViewModel.swift
+++ b/Splitty/Splitty/ViewModels/BalancesViewModel.swift
@@ -1,0 +1,118 @@
+//
+//  BalancesViewModel.swift
+//  Splitty
+//
+
+import Foundation
+
+struct BalanceSheetContext {
+    let groupId: Int
+    let initialNetCents: Int
+    let balancesPending: Bool
+}
+
+struct BalanceRow: Identifiable, Equatable {
+    enum Direction: Equatable {
+        case youOwe
+        case owedToYou
+    }
+
+    let peerId: Int
+    let peerName: String
+    let peerAvatarURL: URL?
+    let amountCents: Int
+    let direction: Direction
+
+    var id: Int { peerId }
+    var magnitudeCents: Int { abs(amountCents) }
+
+    var statement: String {
+        switch direction {
+        case .youOwe:
+            "You owe \(peerName) \(Money.formatted(cents: magnitudeCents))"
+        case .owedToYou:
+            "\(peerName) owes you \(Money.formatted(cents: magnitudeCents))"
+        }
+    }
+}
+
+enum BalancesDisplayState: Equatable {
+    case loading
+    case balances([BalanceRow])
+    case settled
+    case error(String)
+}
+
+@MainActor
+final class BalancesViewModel: ObservableObject {
+    let groupId: Int
+
+    @Published private(set) var state: BalancesDisplayState = .loading
+    @Published private(set) var netCents: Int
+    @Published private(set) var balancesPending: Bool
+
+    init(context: BalanceSheetContext) {
+        groupId = context.groupId
+        netCents = context.initialNetCents
+        balancesPending = context.balancesPending
+    }
+
+    var rows: [BalanceRow] {
+        guard case .balances(let rows) = state else { return [] }
+        return rows
+    }
+
+    var largestMagnitudeCents: Int {
+        rows.map(\.magnitudeCents).max() ?? 1
+    }
+
+    func load(currentUserId: Int) async {
+        do {
+            apply(try await GroupService.shared.getBalanceSummary(groupId: groupId), currentUserId: currentUserId)
+        } catch {
+            fail(with: error)
+        }
+    }
+
+    /// Requests a replay, then takes one fresh snapshot. The pending flag explains that the
+    /// snapshot may still predate the worker; it is not treated as a lock and is not polled.
+    func refresh(currentUserId: Int) async {
+        do {
+            try await GroupService.shared.requestBalanceRecomputation(groupId: groupId)
+            apply(try await GroupService.shared.getBalanceSummary(groupId: groupId), currentUserId: currentUserId)
+        } catch {
+            fail(with: error)
+        }
+    }
+
+    /// Display seam: transforms a decoded API snapshot into exactly what the sheet states.
+    func apply(_ summary: GroupBalanceSummary, currentUserId: Int) {
+        let balances = summary.balances.filter { $0.userId == currentUserId }
+        netCents = balances.reduce(0) { $0 + $1.amountCents }
+        balancesPending = summary.balancesPending
+
+        let openRows = balances
+            .filter { $0.amountCents != 0 }
+            .map { balance in
+                BalanceRow(
+                    peerId: balance.peerId,
+                    peerName: balance.peer.name,
+                    peerAvatarURL: balance.peer.avatarURL,
+                    amountCents: balance.amountCents,
+                    direction: balance.amountCents < 0 ? .youOwe : .owedToYou
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.direction != rhs.direction {
+                    return lhs.direction == .youOwe
+                }
+                return lhs.magnitudeCents > rhs.magnitudeCents
+            }
+
+        state = openRows.isEmpty ? .settled : .balances(openRows)
+    }
+
+    func fail(with error: Error) {
+        state = .error(error.displayMessage)
+    }
+}

--- a/Splitty/Splitty/ViewModels/GroupsViewModel.swift
+++ b/Splitty/Splitty/ViewModels/GroupsViewModel.swift
@@ -12,6 +12,12 @@ class GroupsViewModel: ObservableObject {
     @Published var groups: [Group] = []
     @Published var errorMessage: String?
     @Published var isLoading = false
+
+    /// Nil distinguishes an empty groups list from a real, all-settled total.
+    var overallBalanceCents: Int? {
+        guard !groups.isEmpty else { return nil }
+        return groups.reduce(0) { $0 + $1.netBalanceCents }
+    }
     
     func loadGroups() async {
         isLoading = true

--- a/Splitty/Splitty/Views/BalancesView.swift
+++ b/Splitty/Splitty/Views/BalancesView.swift
@@ -1,0 +1,200 @@
+//
+//  BalancesView.swift
+//  Splitty
+//
+
+import SwiftUI
+
+struct BalancesView: View {
+    let currentUserId: Int
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: BalancesViewModel
+
+    init(context: BalanceSheetContext, currentUserId: Int) {
+        self.currentUserId = currentUserId
+        _viewModel = StateObject(wrappedValue: BalancesViewModel(context: context))
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    netHeader
+                        .listRowInsets(EdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20))
+                        .listRowBackground(Color("background"))
+                        .listRowSeparator(.hidden)
+                }
+
+                Section("Open balances") {
+                    content
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Color("background"))
+            .navigationTitle("Balances")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .refreshable {
+                await viewModel.refresh(currentUserId: currentUserId)
+            }
+            .task {
+                await viewModel.load(currentUserId: currentUserId)
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var netHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Your balance")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Color("muted-foreground"))
+
+            HStack(spacing: 10) {
+                Text(BalanceCopy.overall(cents: viewModel.netCents))
+                    .font(.title2.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(Color("foreground"))
+                    .opacity(viewModel.balancesPending ? 0.5 : 1)
+
+                if viewModel.balancesPending {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.state {
+        case .loading:
+            HStack(spacing: 10) {
+                ProgressView()
+                Text("Loading balances…")
+                    .foregroundStyle(Color("muted-foreground"))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .listRowBackground(Color("card"))
+
+        case .settled:
+            Label("Everyone is settled up", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(Color("muted-foreground"))
+                .listRowBackground(Color("card"))
+
+        case .error(let message):
+            VStack(alignment: .leading, spacing: 12) {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+
+                Button("Try again") {
+                    Task { await viewModel.load(currentUserId: currentUserId) }
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.vertical, 4)
+            .listRowBackground(Color("card"))
+
+        case .balances(let rows):
+            ForEach(rows) { row in
+                BalancePeerRow(
+                    row: row,
+                    largestMagnitudeCents: viewModel.largestMagnitudeCents,
+                    numbersArePending: viewModel.balancesPending
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color("card"))
+            }
+        }
+    }
+}
+
+private struct BalancePeerRow: View {
+    let row: BalanceRow
+    let largestMagnitudeCents: Int
+    let numbersArePending: Bool
+
+    private var fraction: CGFloat {
+        CGFloat(row.magnitudeCents) / CGFloat(max(largestMagnitudeCents, 1))
+    }
+
+    private var directionColor: Color {
+        row.direction == .youOwe ? .red : .green
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            peerAvatar
+
+            Text(
+                row.direction == .youOwe
+                    ? "You owe \(row.peerName)"
+                    : "\(row.peerName) owes you"
+            )
+            .font(.body.weight(.semibold))
+            .foregroundStyle(Color("card-foreground"))
+
+            Spacer(minLength: 12)
+
+            Text(Money.formatted(cents: row.magnitudeCents))
+                .font(.body.weight(.semibold))
+                .monospacedDigit()
+                .foregroundStyle(directionColor)
+                .opacity(numbersArePending ? 0.5 : 1)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(alignment: .leading) {
+            GeometryReader { geometry in
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(directionColor.opacity(0.14))
+                    .frame(width: geometry.size.width * fraction)
+            }
+            .padding(.vertical, 4)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(row.statement)
+        .accessibilityValue(numbersArePending ? "Updating" : "")
+    }
+
+    private var peerAvatar: some View {
+        AsyncImage(url: row.peerAvatarURL) { phase in
+            if case .success(let image) = phase {
+                image.resizable().scaledToFill()
+            } else {
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable()
+                    .foregroundStyle(Color("muted-foreground"))
+            }
+        }
+        .frame(width: 40, height: 40)
+        .clipShape(Circle())
+    }
+}
+
+enum BalanceCopy {
+    static func overall(cents: Int) -> String {
+        if cents > 0 {
+            "You are owed \(Money.formatted(cents: cents)) overall"
+        } else if cents < 0 {
+            "You owe \(Money.formatted(cents: abs(cents))) overall"
+        } else {
+            "You are all settled up"
+        }
+    }
+}
+
+#Preview {
+    BalancesView(
+        context: BalanceSheetContext(groupId: 1, initialNetCents: -23_585, balancesPending: false),
+        currentUserId: 4
+    )
+}

--- a/Splitty/Splitty/Views/GroupView.swift
+++ b/Splitty/Splitty/Views/GroupView.swift
@@ -15,6 +15,7 @@ struct GroupView: View {
     @State private var isTitleCollapsed = false
     @State private var showingEditSheet = false
     @State private var showingExpenseSheet = false
+    @State private var showingBalancesSheet = false
     @State private var pendingDeletion: Expense?
     @State private var selectedExpenseId: Int?
 
@@ -93,6 +94,18 @@ struct GroupView: View {
                 ) { saved in
                     viewModel.insert(saved)
                 }
+            }
+        }
+        .sheet(isPresented: $showingBalancesSheet) {
+            if let group = viewModel.group, let currentUserId {
+                BalancesView(
+                    context: BalanceSheetContext(
+                        groupId: groupId,
+                        initialNetCents: group.netBalanceCents,
+                        balancesPending: viewModel.balancesPending
+                    ),
+                    currentUserId: currentUserId
+                )
             }
         }
         // A money write enqueues a recomputation, so the header balance is stale on return.
@@ -300,17 +313,9 @@ struct GroupView: View {
     
     @ViewBuilder
     private var balanceText: some View {
-        if let balance = viewModel.group?.netBalance {
+        if let balanceCents = viewModel.group?.netBalanceCents {
             HStack(spacing: 6) {
-                SwiftUI.Group {
-                    if balance > 0 {
-                        Text("You are owed \(Money.formatted(amount: balance)) overall")
-                    } else if balance < 0 {
-                        Text("You owe \(Money.formatted(amount: abs(balance))) overall")
-                    } else {
-                        Text("You are all settled up")
-                    }
-                }
+                Text(BalanceCopy.overall(cents: balanceCents))
                 // A recomputation is outstanding, so this number predates the last write.
                 // Greyed with a spinner rather than presented as final.
                 .foregroundColor(Color("muted-foreground"))
@@ -338,8 +343,9 @@ struct GroupView: View {
             }
             
             ActionButton(title: "Balances", color: Color("muted"), textColor: Color("foreground")) {
-                // TODO: Balances action
+                showingBalancesSheet = true
             }
+            .disabled(viewModel.group == nil || currentUserId == nil)
             
             ActionButton(title: "Export", color: Color("muted"), textColor: Color("foreground")) {
                 // TODO: Export action

--- a/Splitty/Splitty/Views/GroupsView.swift
+++ b/Splitty/Splitty/Views/GroupsView.swift
@@ -23,7 +23,10 @@ struct GroupsView: View {
                             .font(.largeTitle)
                             .fontWeight(.bold)
                         
-                        Text("Overall, you are owed $320.43")
+                        if let overallBalanceCents = viewModel.overallBalanceCents {
+                            Text(BalanceCopy.overall(cents: overallBalanceCents))
+                                .foregroundColor(Color("muted-foreground"))
+                        }
                     }
                     
                     Spacer()

--- a/Splitty/SplittyTests/BalancesViewModelTests.swift
+++ b/Splitty/SplittyTests/BalancesViewModelTests.swift
@@ -126,6 +126,15 @@ struct BalanceDecodingTests {
         #expect(decoded.balancesPending)
     }
 
+    @Test func anEmptyAvatarURLDoesNotRejectTheSummary() throws {
+        let payload = #"{"balances":[{"userId":1,"peerId":2,"amount":12.00,"user":{"id":1,"name":"You","email":"you@example.com","avatarUrl":"","createdAt":"2026-01-01","updatedAt":"2026-01-01"},"peer":{"id":2,"name":"Ana","email":"ana@example.com","avatarUrl":"","createdAt":"2026-01-01","updatedAt":"2026-01-01"}}],"balancesPending":false}"#
+
+        let decoded = try JSONDecoder().decode(GroupBalanceSummary.self, from: Data(payload.utf8))
+        let row = try #require(decoded.balances.first)
+        #expect(row.user.avatarURL == nil)
+        #expect(row.peer.avatarURL == nil)
+    }
+
     @Test func decodesGroupNetBalanceToCentsAtTheBoundary() throws {
         let payload = #"{"id":7,"name":"Trip","description":null,"netBalance":12.34,"createdAt":"2026-01-01","members":[]}"#
         let group = try JSONDecoder().decode(Group.self, from: Data(payload.utf8))

--- a/Splitty/SplittyTests/BalancesViewModelTests.swift
+++ b/Splitty/SplittyTests/BalancesViewModelTests.swift
@@ -1,0 +1,155 @@
+//
+//  BalancesViewModelTests.swift
+//  SplittyTests
+//
+
+import Foundation
+import Testing
+@testable import Splitty
+
+@MainActor
+struct BalancesViewModelTests {
+    @Test func zeroRowsAreHiddenAndAnAllZeroSummaryIsSettled() {
+        let viewModel = makeViewModel(initialNetCents: 1_200)
+        viewModel.apply(summary([balance(peerId: 2, name: "Ana", cents: 0)]), currentUserId: 1)
+
+        #expect(viewModel.state == .settled)
+        #expect(viewModel.netCents == 0)
+    }
+
+    @Test func aSummaryWithNoRowsIsSettled() {
+        let viewModel = makeViewModel()
+        viewModel.apply(summary([]), currentUserId: 1)
+        #expect(viewModel.state == .settled)
+    }
+
+    @Test func debtsComeBeforeCreditsAndLargestAmountsComeFirst() {
+        let viewModel = makeViewModel()
+        viewModel.apply(summary([
+            balance(peerId: 2, name: "Small credit", cents: 300),
+            balance(peerId: 3, name: "Small debt", cents: -200),
+            balance(peerId: 4, name: "Large credit", cents: 900),
+            balance(peerId: 5, name: "Large debt", cents: -800)
+        ]), currentUserId: 1)
+
+        #expect(viewModel.rows.map(\.peerName) == ["Large debt", "Small debt", "Large credit", "Small credit"])
+    }
+
+    @Test func directionIsWrittenInWords() {
+        let viewModel = makeViewModel()
+        viewModel.apply(summary([
+            balance(peerId: 2, name: "Ana", cents: -4_000),
+            balance(peerId: 3, name: "Bob", cents: 1_200)
+        ]), currentUserId: 1)
+
+        #expect(viewModel.rows.map(\.statement) == ["You owe Ana $40.00", "Bob owes you $12.00"])
+    }
+
+    @Test func summaryNetReplacesTheAlreadyLoadedGroupNet() {
+        let viewModel = makeViewModel(initialNetCents: 9_999)
+        #expect(viewModel.netCents == 9_999)
+
+        viewModel.apply(summary([
+            balance(peerId: 2, name: "Hidden", cents: 0),
+            balance(peerId: 3, name: "Ana", cents: -4_000),
+            balance(peerId: 4, name: "Bob", cents: 1_200)
+        ]), currentUserId: 1)
+
+        #expect(viewModel.netCents == -2_800)
+    }
+
+    @Test func aFailureIsDistinctFromSettled() {
+        let viewModel = makeViewModel()
+        viewModel.fail(with: TestFailure())
+
+        #expect(viewModel.state == .error("Could not load balances"))
+    }
+
+    @Test func pendingDoesNotChangeWhichRowsAppear() {
+        let viewModel = makeViewModel()
+        viewModel.apply(
+            summary([balance(peerId: 2, name: "Ana", cents: -4_000)], pending: true),
+            currentUserId: 1
+        )
+
+        #expect(viewModel.balancesPending)
+        #expect(viewModel.rows.map(\.peerName) == ["Ana"])
+    }
+
+    @Test func onlyTheCurrentUsersRowsContribute() {
+        let viewModel = makeViewModel()
+        viewModel.apply(summary([
+            balance(userId: 9, peerId: 2, name: "Other side", cents: 4_000),
+            balance(peerId: 3, name: "Ana", cents: -1_000)
+        ]), currentUserId: 1)
+
+        #expect(viewModel.rows.map(\.peerName) == ["Ana"])
+        #expect(viewModel.netCents == -1_000)
+    }
+
+    private func makeViewModel(initialNetCents: Int = 0) -> BalancesViewModel {
+        BalancesViewModel(
+            context: BalanceSheetContext(groupId: 7, initialNetCents: initialNetCents, balancesPending: false)
+        )
+    }
+
+    private func summary(_ balances: [Balance], pending: Bool = false) -> GroupBalanceSummary {
+        GroupBalanceSummary(balances: balances, balancesPending: pending)
+    }
+
+    private func balance(userId: Int = 1, peerId: Int, name: String, cents: Int) -> Balance {
+        Balance(
+            userId: userId,
+            peerId: peerId,
+            amountCents: cents,
+            user: user(id: userId, name: "You"),
+            peer: user(id: peerId, name: name)
+        )
+    }
+
+    private func user(id: Int, name: String) -> User {
+        User(id: id, name: name, email: "\(id)@example.com", createdAt: "2026-01-01", updatedAt: "2026-01-01")
+    }
+}
+
+struct BalanceDecodingTests {
+    @Test func decodesSummaryMoneyAndInlinedPeerAtTheBoundary() throws {
+        let payload = #"{"balances":[{"userId":1,"peerId":2,"amount":-40.25,"user":{"id":1,"name":"You","email":"you@example.com","createdAt":"2026-01-01","updatedAt":"2026-01-01"},"peer":{"id":2,"name":"Ana","email":"ana@example.com","avatarUrl":"https://example.com/ana.png","createdAt":"2026-01-01","updatedAt":"2026-01-01"}}],"balancesPending":true}"#
+
+        let decoded = try JSONDecoder().decode(GroupBalanceSummary.self, from: Data(payload.utf8))
+        let row = try #require(decoded.balances.first)
+
+        #expect(row.peerId == 2)
+        #expect(row.peer.name == "Ana")
+        #expect(row.peer.avatarURL == URL(string: "https://example.com/ana.png"))
+        #expect(row.amountCents == -4_025)
+        #expect(decoded.balancesPending)
+    }
+
+    @Test func decodesGroupNetBalanceToCentsAtTheBoundary() throws {
+        let payload = #"{"id":7,"name":"Trip","description":null,"netBalance":12.34,"createdAt":"2026-01-01","members":[]}"#
+        let group = try JSONDecoder().decode(Group.self, from: Data(payload.utf8))
+        #expect(group.netBalanceCents == 1_234)
+    }
+}
+
+@MainActor
+struct GroupsOverallBalanceTests {
+    @Test func sumsLoadedGroupNets() {
+        let viewModel = GroupsViewModel()
+        viewModel.groups = [group(id: 1, cents: 1_234), group(id: 2, cents: -234)]
+        #expect(viewModel.overallBalanceCents == 1_000)
+    }
+
+    @Test func hasNoOverallFigureWithoutGroups() {
+        #expect(GroupsViewModel().overallBalanceCents == nil)
+    }
+
+    private func group(id: Int, cents: Int) -> Group {
+        Group(id: id, name: "Group \(id)", description: nil, netBalanceCents: cents, createdAt: "2026-01-01", members: [])
+    }
+}
+
+private struct TestFailure: LocalizedError {
+    var errorDescription: String? { "Could not load balances" }
+}


### PR DESCRIPTION
Closes #43

Stacked on #44.

## What changed

- adds a balances sheet from the existing group action
- uses the selected proportional-fill row layout
- lists debts before credits and sorts each direction by amount
- hides settled pairs and distinguishes settled, loading, pending, and error states
- supports retry and pull-to-recompute without polling
- replaces the hardcoded groups total with the sum of loaded group nets
- decodes all balance and group money into integer cents at the API boundary
- removes the debug layout prototype and its Settings entry

## Verification

- focused balance view-model and decoding tests pass
- full `SplittyTests` suite passes on iPhone 17 / iOS 26.5 simulator
- final two-axis review passed after fixing visible credit wording and consolidating `GroupDetail`
